### PR TITLE
Basic sliderule v4 for minimal example

### DIFF
--- a/SlideRule/S01_SlideRule_compare.py
+++ b/SlideRule/S01_SlideRule_compare.py
@@ -40,8 +40,8 @@ import generalized_FT as gFT
 xr.set_options(display_style='text')
 
 #matplotlib.use('agg')
-%matplotlib inline
-%matplotlib widget
+# %matplotlib inline
+# %matplotlib widget
 
 
 # %% define functions
@@ -107,15 +107,15 @@ hemis, batch = batch_key.split('_')
 all_beams   = mconfig['beams']['all_beams']
 
 load_path_work   = mconfig['paths']['work'] +'/'+ batch_key +'/'
-B2_hdf5    = h5py.File(load_path_work +'B01_regrid'+'/'+ID_name + '_B01_regridded.h5', 'r')
-B3_hdf5    = h5py.File(load_path_work +'B01_regrid'+'/'+ID_name + '_B01_binned.h5', 'r')
+B01r_hdf5    = h5py.File(load_path_work +'B01_regrid'+'/'+ID_name + '_B01_regridded.h5', 'r')
+B01b_hdf5    = h5py.File(load_path_work +'B01_regrid'+'/'+ID_name + '_B01_binned.h5', 'r')
 
-B2, B3 = dict(), dict()
+B01r, B01b = dict(), dict()
 for b in all_beams:
-    B2[b] = io.get_beam_hdf_store(B2_hdf5[b])
-    B3[b] = io.get_beam_hdf_store(B3_hdf5[b])
+    B01r[b] = io.get_beam_hdf_store(B01r_hdf5[b])
+    B01b[b] = io.get_beam_hdf_store(B01b_hdf5[b])
 
-B2_hdf5.close(), B2_hdf5.close()
+B01r_hdf5.close(), B01r_hdf5.close()
 
 
 
@@ -123,7 +123,7 @@ B2_hdf5.close(), B2_hdf5.close()
 
 # Configure Session #
 #icesat2.init("icesat2sliderule.org", True)
-icesat2.init("slideruleearth.io", True) #doesn't work
+icesat2.init("slideruleearth.io", True) 
 asset = 'nsidc-s3'
 
 # %%
@@ -197,7 +197,7 @@ for llen in [10, 20, 30]:
 # %%
 #for b in all_beams:
 
-def init_compare_figure(B2i, B3i, lims):
+def init_compare_figure(B01ri, B01bi, lims):
 
     F = M.figure_axis_xy(6,4, view_scale=0.7, container=True)
     grid = F.fig.add_gridspec(2, 4, wspace=0.1, hspace=0.8)
@@ -212,15 +212,15 @@ def init_compare_figure(B2i, B3i, lims):
 
     # init basic data
     plt.sca(axx[1])
-    plt.plot( B2i.lats, B2i.heights, '.', color = 'gray', markersize=0.8, alpha = 0.6)
-    plt.plot( B3i.lats, B3i.heights, '-k', lw=0.8, label='B03 H&H 2023', zorder=12)
-    #plt.plot( B3i.lats, B3i.heights, '.k', markersize = 1.2)
+    plt.plot( B01ri.lats, B01ri.heights, '.', color = 'gray', markersize=0.8, alpha = 0.6)
+    plt.plot( B01bi.lats, B01bi.heights, '-k', lw=0.8, label='B01_binned H&H 2023', zorder=12)
+    #plt.plot( B01bi.lats, B01bi.heights, '.k', markersize = 1.2)
 
 
     plt.sca(axx[2])
-    B3i_gradient = -np.gradient(B3i.heights_c_weighted_mean)
-    # plt.plot( B2i.lats, B2i.heights_c, '.k', markersize=0.5)
-    plt.plot( B3i.lats, B3i_gradient, '-k', lw=0.8, label='B03 H&H 2023', zorder=12)
+    B01bi_gradient = -np.gradient(B01bi.heights_c_weighted_mean)
+    # plt.plot( B01ri.lats, B01ri.heights_c, '.k', markersize=0.5)
+    plt.plot( B01bi.lats, B01bi_gradient, '-k', lw=0.8, label='B01_binned H&H 2023', zorder=12)
 
 
     axx[1].set_title('Height Timeseries', loc='left')
@@ -239,7 +239,7 @@ def init_compare_figure(B2i, B3i, lims):
     #axx[4].set_xlabel('Gradient')
     #axx[4].set_ylabel('Gradient')
 
-    return F, axx, B3i_gradient
+    return F, axx, B01bi_gradient
 
 # %%
 def add_data(axx, data, delta_y, dx,  color, label, alpha=1.0, scatter=True):
@@ -253,39 +253,39 @@ def add_data(axx, data, delta_y, dx,  color, label, alpha=1.0, scatter=True):
     axx[2].plot( data_x, data_dx, color, lw=1.2, label=label, alpha=alpha)
 
     if scatter:
-        if B3i.heights.size > h_mean.size:
-            axx[3].scatter( B3i.heights[0:-1], h_mean, 1, c=color, label=label)
-            axx[4].scatter( B3i_gradient[0:-1], data_dx, 1, c=color , label=label)
+        if B01bi.heights.size > h_mean.size:
+            axx[3].scatter( B01bi.heights[0:-1], h_mean, 1, c=color, label=label)
+            axx[4].scatter( B01bi_gradient[0:-1], data_dx, 1, c=color , label=label)
         else:
-            axx[3].scatter( B3i.heights, h_mean, 1, c=color, label=label)
-            axx[4].scatter( B3i_gradient, data_dx, 1, c=color , label=label)
+            axx[3].scatter( B01bi.heights, h_mean, 1, c=color, label=label)
+            axx[4].scatter( B01bi_gradient, data_dx, 1, c=color , label=label)
 
     axx[3].plot( h_mean, h_mean, '-k', lw=0.5)
-    axx[4].plot( B3i_gradient[0:-1], B3i_gradient[0:-1] , '-k', lw=0.5)
+    axx[4].plot( B01bi_gradient[0:-1], B01bi_gradient[0:-1] , '-k', lw=0.5)
 
 
 b, spot = 'gt1r', 2
-B3i = B3[b][3:110]
+B01bi = B01b[b][3:110]
 
 # b, spot = 'gt3r', 6
-# B3i = B3[b][2:102]
+# B01bi = B01b[b][2:102]
 
-lims = [B3i.lats.min(),  B3i.lats.max() ] 
+lims = [B01bi.lats.min(),  B01bi.lats.max() ] 
 # select data given limits
-B2i           = select_beam_section(B2, b, lims)
+B01ri           = select_beam_section(B01r, b, lims)
 
-F, axx,B3i_gradient = init_compare_figure(B2i, B3i, lims)
+F, axx,B01bi_gradient = init_compare_figure(B01ri, B01bi, lims)
 
 ## add more data
-B3_atl06_native = select_beam_section(ATL06_native[20], spot, lims)
-B3_atl06_yapc   = select_beam_section(ATL06_yapc[20], spot, lims)
+B01b_atl06_native = select_beam_section(ATL06_native[20], spot, lims)
+B01b_atl06_yapc   = select_beam_section(ATL06_yapc[20], spot, lims)
 
 delta_y = 0.0
-add_data(axx, B3_atl06_native, delta_y,10,  'orange', 'ATL06 +'+str(delta_y), alpha=0.8, scatter=False) 
-#axx[2].plot(B3_atl06_native.geometry.y, -np.gradient(B3_atl06_native.h_mean)+0.02, 'darkgreen' )
+add_data(axx, B01b_atl06_native, delta_y,10,  'orange', 'ATL06 +'+str(delta_y), alpha=0.8, scatter=False) 
+#axx[2].plot(B01b_atl06_native.geometry.y, -np.gradient(B01b_atl06_native.h_mean)+0.02, 'darkgreen' )
 
-add_data(axx, B3_atl06_yapc, delta_y, 10,  'g', 'ATL06 YAPC +'+str(delta_y), alpha=0.8, scatter=False) 
-#axx[2].plot(B3_atl06_yapc.geometry.y, -np.gradient(B3_atl06_yapc.h_mean) - 0.02 , 'lightgreen' )
+add_data(axx, B01b_atl06_yapc, delta_y, 10,  'g', 'ATL06 YAPC +'+str(delta_y), alpha=0.8, scatter=False) 
+#axx[2].plot(B01b_atl06_yapc.geometry.y, -np.gradient(B01b_atl06_yapc.h_mean) - 0.02 , 'lightgreen' )
 
 axx[1].legend(ncol=3)
 F.fig.suptitle('ATL06 native vs. YAPC')
@@ -294,32 +294,36 @@ plt.show()
 
 F.save_light(name ='SlideRule_ATL06_compare_weak', path=plot_path)
 
+B01bi.T
+B01b_atl06_native.T
+B01b_atl06_native['geometry'].x
+B01b_atl06_native['geometry'].y
 
 # %% Test windowing ATL06_native
 
 #b, spot = 'gt3r', 6
 b, spot = 'gt1r', 2
 
-B3i = B3[b][3:110]
-lims = [B3i.lats.min(),  B3i.lats.max() ] 
+B01bi = B01b[b][3:110]
+lims = [B01bi.lats.min(),  B01bi.lats.max() ] 
 # select data given limits
-B2i           = select_beam_section(B2, b, lims)
+B01ri           = select_beam_section(B01r, b, lims)
 
-F, axx, B3i_gradient = init_compare_figure(B2i, B3i, lims)
+F, axx, B01bi_gradient = init_compare_figure(B01ri, B01bi, lims)
 
 ## add data
 delta_y=0.0
 for ll,ccol in zip([10, 20, 30], ['green', 'darkorange', 'red']):
-    B3_atl06_native = select_beam_section(ATL06_native[ll], spot, lims)
+    B01b_atl06_native = select_beam_section(ATL06_native[ll], spot, lims)
 
     delta_y += 0.1
-    add_data(axx, B3_atl06_native, delta_y,10,  ccol, 'len='+ str(ll) +'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
-    #axx[2].plot(B3_atl06_native.geometry.y, -np.gradient(B3_atl06_native.h_mean)+0.02, 'darkgreen' )
+    add_data(axx, B01b_atl06_native, delta_y,10,  ccol, 'len='+ str(ll) +'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
+    #axx[2].plot(B01b_atl06_native.geometry.y, -np.gradient(B01b_atl06_native.h_mean)+0.02, 'darkgreen' )
 
 axx[1].legend(ncol=3)
 
-axx[1].set_ylim(B3i.heights.min(), B3i.heights.max()+0.2)
-axx[2].set_ylim( np.nanmin(B3i_gradient), np.nanmax(B3i_gradient))
+axx[1].set_ylim(B01bi.heights.min(), B01bi.heights.max()+0.2)
+axx[2].set_ylim( np.nanmin(B01bi_gradient), np.nanmax(B01bi_gradient))
 F.fig.suptitle('ATL06 native')
 
 F.save_light(name ='SlideRule_ATL06_native_window_weak', path=plot_path)
@@ -330,26 +334,26 @@ plt.show()
 
 b, spot = 'gt1r', 2
 
-B3i = B3[b][3:102]
-lims = [B3i.lats.min(),  B3i.lats.max() ] 
+B01bi = B01b[b][3:102]
+lims = [B01bi.lats.min(),  B01bi.lats.max() ] 
 # select data given limits
-B2i           = select_beam_section(B2, b, lims)
+B01ri           = select_beam_section(B01r, b, lims)
 
-F, axx, B3i_gradient = init_compare_figure(B2i, B3i, lims)
+F, axx, B01bi_gradient = init_compare_figure(B01ri, B01bi, lims)
 
 ## add data
 delta_y=0.0
 for ll,ccol in zip([10, 20, 30], ['green', 'darkorange', 'red']):
-    B3_atl06_yapc = select_beam_section(ATL06_yapc[ll], spot, lims)
+    B01b_atl06_yapc = select_beam_section(ATL06_yapc[ll], spot, lims)
 
     delta_y += 0.1
-    add_data(axx, B3_atl06_yapc, delta_y,10,  ccol, 'len='+str(ll)+'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
-    #axx[2].plot(B3_atl06_native.geometry.y, -np.gradient(B3_atl06_native.h_mean)+0.02, 'darkgreen' )
+    add_data(axx, B01b_atl06_yapc, delta_y,10,  ccol, 'len='+str(ll)+'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
+    #axx[2].plot(B01b_atl06_native.geometry.y, -np.gradient(B01b_atl06_native.h_mean)+0.02, 'darkgreen' )
 
 axx[1].legend(ncol=3)
 
-axx[1].set_ylim(B3i.heights.min(), B3i.heights.max()+0.2)
-axx[2].set_ylim( np.nanmin(B3i_gradient), np.nanmax(B3i_gradient))
+axx[1].set_ylim(B01bi.heights.min(), B01bi.heights.max()+0.2)
+axx[2].set_ylim( np.nanmin(B01bi_gradient), np.nanmax(B01bi_gradient))
 F.fig.suptitle('ATL06 YAPC')
 plt.show()
 #F.save_light(name ='SlideRule_ATL06_yapc_window_weak', path=plot_path)
@@ -411,46 +415,46 @@ for wwin_h  in [0, 10, 20]:
 # %%
 
 b, spot = 'gt1r', 2
-B3i = B3[b][3:102]
-lims = [B3i.lats.min(),  B3i.lats.max() ] 
+B01bi = B01b[b][3:102]
+lims = [B01bi.lats.min(),  B01bi.lats.max() ] 
 # select data given limits
-B2i           = select_beam_section(B2, b, lims)
+B01ri           = select_beam_section(B01r, b, lims)
 
-F, axx, B3i_gradient = init_compare_figure(B2i, B3i, lims)
+F, axx, B01bi_gradient = init_compare_figure(B01ri, B01bi, lims)
 
 ## add data
 delta_y=0.0
 for ll,ccol in zip( list(ATL06_yapc_winx.keys()) , ['green', 'darkorange', 'red']):
-    B3_atl06_yapc = select_beam_section(ATL06_yapc_winx[ll], spot, lims)
+    B01b_atl06_yapc = select_beam_section(ATL06_yapc_winx[ll], spot, lims)
 
     delta_y += 0.0
-    add_data(axx, B3_atl06_yapc, delta_y,10,  ccol, 'win_x='+str(ll)+'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
-    #axx[2].plot(B3_atl06_native.geometry.y, -np.gradient(B3_atl06_native.h_mean)+0.02, 'darkgreen' )
+    add_data(axx, B01b_atl06_yapc, delta_y,10,  ccol, 'win_x='+str(ll)+'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
+    #axx[2].plot(B01b_atl06_native.geometry.y, -np.gradient(B01b_atl06_native.h_mean)+0.02, 'darkgreen' )
 
 axx[1].legend(ncol=2)
 
-axx[1].set_ylim(B3i.heights.min(), B3i.heights.max()+0.2)
-axx[2].set_ylim( np.nanmin(B3i_gradient), np.nanmax(B3i_gradient))
+axx[1].set_ylim(B01bi.heights.min(), B01bi.heights.max()+0.2)
+axx[2].set_ylim( np.nanmin(B01bi_gradient), np.nanmax(B01bi_gradient))
 F.fig.suptitle('ATL06 YAPC win_x comapare')
 plt.show()
 
 
 # win_h
-F, axx, B3i_gradient = init_compare_figure(B2i, B3i, lims)
+F, axx, B01bi_gradient = init_compare_figure(B01ri, B01bi, lims)
 
 ## add data
 delta_y=0.0
 for ll,ccol in zip( list(ATL06_yapc_winh.keys()) , ['green', 'darkorange', 'red']):
-    B3_atl06_yapc = select_beam_section(ATL06_yapc_winh[ll], spot, lims)
+    B01b_atl06_yapc = select_beam_section(ATL06_yapc_winh[ll], spot, lims)
 
     delta_y += 0.0
-    add_data(axx, B3_atl06_yapc, delta_y,10,  ccol, 'win_h='+str(ll)+'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
-    #axx[2].plot(B3_atl06_native.geometry.y, -np.gradient(B3_atl06_native.h_mean)+0.02, 'darkgreen' )
+    add_data(axx, B01b_atl06_yapc, delta_y,10,  ccol, 'win_h='+str(ll)+'| +' +str(np.round(delta_y, 2)), alpha=0.8, scatter=False) 
+    #axx[2].plot(B01b_atl06_native.geometry.y, -np.gradient(B01b_atl06_native.h_mean)+0.02, 'darkgreen' )
 
 axx[1].legend(ncol=2)
 
-axx[1].set_ylim(B3i.heights.min(), B3i.heights.max()+0.2)
-axx[2].set_ylim( np.nanmin(B3i_gradient), np.nanmax(B3i_gradient))
+axx[1].set_ylim(B01bi.heights.min(), B01bi.heights.max()+0.2)
+axx[2].set_ylim( np.nanmin(B01bi_gradient), np.nanmax(B01bi_gradient))
 F.fig.suptitle('ATL06 YAPC win_h comapare')
 plt.show()
 
@@ -504,24 +508,24 @@ gdf_seaice = icesat2.atl03s(parms, asset=asset,  resource=track_name)#granules_l
 # %%
 
 b, spot = 'gt1r', 2
-#B3i = B3[b][600:702]
-B3i = B3[b][0:102]
+#B01bi = B01b[b][600:702]
+B01bi = B01b[b][0:102]
 
-lims = [B3i.lats.min(),  B3i.lats.max() ] 
+lims = [B01bi.lats.min(),  B01bi.lats.max() ] 
 # select data given limits
-B2i           = select_beam_section(B2, b, lims)
+B01ri           = select_beam_section(B01r, b, lims)
 
-#F, axx, B3i_gradient = init_compare_figure(B2i, B3i, lims)
+#F, axx, B01bi_gradient = init_compare_figure(B01ri, B01bi, lims)
 
 gdfi           = select_beam_section(gdf, spot, lims)
 gdf_seaicei    = select_beam_section(gdf_seaice, spot, lims)
 
-# Make 1 panel figure with B3i.heights and gdfi.height
+# Make 1 panel figure with B01bi.heights and gdfi.height
 F = M.figure_axis_xy(7.5, 3)
 ax =F.ax
 
-ax.plot( B2i.lats, B2i.heights, '.', color = 'gray', markersize=0.8, alpha = 0.6)
-ax.plot( B3i.lats, B3i.heights, '-k', lw=0.8, label='B03 H&H 2023', zorder=12)
+ax.plot( B01ri.lats, B01ri.heights, '.', color = 'gray', markersize=0.8, alpha = 0.6)
+ax.plot( B01bi.lats, B01bi.heights, '-k', lw=0.8, label='B01_binned H&H 2023', zorder=12)
 
 score_curoff = 10 #230
 mask = gdfi['yapc_score'] > score_curoff
@@ -535,7 +539,7 @@ ax.plot( gdf_seaicei.geometry.y , gdf_seaicei.height, '+', color = 'red', marker
 
 
 plt.ylim( list(gdfi[mask].height.quantile([0.02, 0.98])) )
-#plt.ylim( list(B3i.heights.quantile([0.01, 0.99])) )
+#plt.ylim( list(B01bi.heights.quantile([0.01, 0.99])) )
 
 plt.legend()
 plt.colorbar(hm)

--- a/SlideRule/S01b_SLv4_minimal_test.py
+++ b/SlideRule/S01b_SLv4_minimal_test.py
@@ -1,0 +1,82 @@
+
+# %%
+"""
+This file open a ICEsat2 track applied filters and corrections and returns smoothed photon heights on a regular grid in an .nc file.
+This is python 3.11
+"""
+
+# exec(open(os.environ["PYTHONSTARTUP"]).read())
+# exec(open(STARTUP_2021_IceSAT2).read())
+import geopandas as gpd
+
+from sliderule import icesat2
+from sliderule import earthdata
+from sliderule import sliderule
+
+import shapely
+
+# %% Configure SL Session #
+
+#sliderule.authenticate("brown", ps_username="mhell", ps_password="Oijaeth9quuh")
+
+icesat2.init("slideruleearth.io", organization="brown", desired_nodes=3, time_to_live=90) #minutes
+
+
+# icesat2.init("slideruleearth.io", True) 
+# asset = 'nsidc-s3'
+
+params={'srt': 1,  # Ocean classification
+        'len': 25,        # 10-meter segments
+        'ats':3,          # require that each segment contain photons separated by at least 5 m
+        'res':10,         # return one photon every 10 m
+        'track': 0,       # return all ground tracks
+        'pass_invalid': True,   
+        'cnf': 2,         # require classification confidence of 2 or more
+        #'iterations':10,  # iterate the fit
+        }
+
+# %% single file test
+track_name = '20190504201233_05580312_005_01'
+ATL03_track_name = 'ATL03_'+track_name+'.h5'
+
+gdf = icesat2.atl06p(params, resources=[ATL03_track_name])
+gdf.plot()
+
+# %% Select region and retrive batch of tracks
+def create_polygons(latR, lonR):
+    from shapely.geometry import Polygon, Point
+    latR.sort()
+    lonR.sort()
+    poly_list=[{'lat':latR[ii], 'lon':lonR[jj]} for ii, jj in zip([1, 1, 0, 0, 1], [1, 0, 0, 1, 1])]
+    polygon_shapely= Polygon([(item['lon'], item['lat']) for item in poly_list])
+    return {    'list':poly_list, 
+                'shapely':polygon_shapely,
+                'lons':lonR,
+                'lats':latR}
+
+# Southern Hemisphere test
+latR, lonR = [-67.2, -62], [140.0, 155.0]
+
+# Northern Hemisphere test
+#latR, lonR = [65.0, 75.0], [140.0, 155.0]
+
+# init polygon opbjects 
+poly = create_polygons(latR, lonR)
+
+# add domain
+params['poly'] = poly['list']
+params['t0'] = '2019-05-01T00:00:00'
+params['t1'] = '2019-05-20T00:00:00'
+#params['t1'] = '2019-06-10T00:00:00'
+
+# get granuale list
+#release = '005'
+granules_list = earthdata.cmr(short_name='ATL03', version = '005', polygon=params['poly'], time_start=params['t0'], time_end=params['t1'],) 
+
+print(granules_list)
+gdf = icesat2.atl06p(params, resources=granules_list)
+
+# %% alternative version
+gdf = icesat2.atl06p(params)
+
+# %%

--- a/SlideRule/S03_SL_to_B01.py
+++ b/SlideRule/S03_SL_to_B01.py
@@ -1,0 +1,347 @@
+# %%
+import os, sys
+
+"""
+This file open a ICEsat2 track applied filters and corections and returns smoothed photon heights on a regular grid in an .nc file.
+This is python 3.11
+"""
+exec(open(os.environ["PYTHONSTARTUP"]).read())
+exec(open(STARTUP_2021_IceSAT2).read())
+
+# import sys
+# import logging
+# import concurrent.futures
+# import time
+# from datetime import datetime
+# import pandas as pd
+import geopandas as gpd
+# import matplotlib.pyplot as plt
+# from pyproj import Transformer, CRS
+from shapely.geometry import Polygon, Point
+from sliderule import icesat2
+from sliderule import sliderule
+# import re
+# import datetime
+import numpy as np
+import shapely
+
+import matplotlib
+
+from ipyleaflet import basemaps
+from ipyleaflet import basemaps, Map, GeoData
+
+import ICEsat2_SI_tools.convert_GPS_time as cGPS
+import h5py
+import ICEsat2_SI_tools.io as io
+import ICEsat2_SI_tools.spectral_estimates as spec
+import ICEsat2_SI_tools.lanczos as lanczos
+import ICEsat2_SI_tools.sliderule_converter_tools as sct
+import imp
+import copy
+import spicke_remover
+import generalized_FT as gFT
+
+xr.set_options(display_style='text')
+
+#matplotlib.use('agg')
+# %matplotlib inline
+# %matplotlib widget
+
+
+plot_path = mconfig['paths']['plot'] +'sliderule_tests/'
+MT.mkdirs_r(plot_path)
+
+load_path_RGT = mconfig['paths']['analysis'] +'../analysis_db/support_files/'
+
+
+
+# %%
+
+# Configure Session #
+icesat2.init("slideruleearth.io", True) 
+asset = 'nsidc-s3'
+
+
+# %% Select region and retrive batch of tracks
+
+# create boundary based on given track information
+# latR  = [np.round(ID['pars']['start']['latitude'], 1), np.round(ID['pars']['end']['latitude'], 1) ]
+# lonR  = [np.round(ID['pars']['start']['longitude'], 1), np.round(ID['pars']['end']['longitude'], 1) ]
+latR = [-67.2, -64.3]
+lonR = [140.0, 145.0]
+
+
+# latR = [65.0, 75.0]
+# lonR = [140.0, 155.0]
+
+latR.sort()
+lonR.sort()
+
+poly_test=[{'lat':latR[ii], 'lon':lonR[jj]} for ii, jj in zip([1, 1, 0, 0, 1], [1, 0, 0, 1, 1])]
+print('new ', latR, lonR)
+
+polygon_shapely= Polygon([(item['lon'], item['lat']) for item in poly_test])
+
+
+# %% load ground track data in domain:
+
+#Gtrack = gpd.read_file(load_path_RGT + 'IS2_mission_points_NH_RGT_all.shp', mask=polygon_shapely)
+Gtrack = gpd.read_file(load_path_RGT + 'IS2_mission_points_SH_RGT_all.shp', mask=poly['shapely'])
+
+m = sct.plot_polygon(poly_test, basemap=basemaps.Esri.WorldImagery, zoom=3)
+#m.add_layer(polygon_shapely, c ='red')
+geo_data = GeoData(geo_dataframe = Gtrack[::5],
+    #style={'color': 'red', 'radius':1},
+    point_style={'radius': 0.1, 'color': 'red', 'fillOpacity': 0.1},
+    name = 'rgt')
+m.add_layer(geo_data)
+m
+
+
+# %%
+
+Gtrack_lowest = sct.get_RGT_start_points(Gtrack)
+Gtrack_highest = sct.get_RGT_end_points(Gtrack)
+
+fig, axx = plt.subplots(1,1, figsize=(4,4))
+
+ax = axx
+ax.set_title("ATL Points")
+
+# FIX THIS TO SHOW EACH RGT value by color
+#G_lowest.plot(ax=ax, column='RGT', label='RGT', c=G_lowest['RGT'], markersize= 5, cmap='winter')
+Gtrack_lowest[1:10].plot(ax=ax, label='RGT', c='red', markersize= 10)
+Gtrack_highest[1:10].plot(ax=ax, label='RGT', c='black', markersize= 10)
+
+for rgt in Gtrack['RGT'].unique()[0:10]:
+    Gtrack[Gtrack['RGT'] == rgt].plot(ax=ax, c='blue', markersize= 0.8, alpha= 0.6)
+
+#ax.legend(loc="upper left")
+# Prepare coordinate lists for plotting the region of interest polygon
+region_lon = [e["lon"] for e in poly_test]
+region_lat = [e["lat"] for e in poly_test]
+ax.plot(region_lon, region_lat, linewidth=1, color='gray');
+
+# labels
+ax.set_xlabel('Longitude')
+ax.set_ylabel('Latitude')
+ax.set_aspect('equal')
+
+# %%
+
+## Generate ATL06-type segments using the ATL03-native photon classification
+# Use the ocean classification for photons with a confidence parmeter to 2 or higher (low confidence or better)
+
+params={'srt': 1,  # Ocean classification
+ 'len': 25,        # 10-meter segments
+ 'ats':3,          # require that each segment contain photons separated by at least 5 m
+ 'res':10,         # return one photon every 10 m
+ 'track': 0,       # return all ground tracks
+ 'pass_invalid': True,   
+ 'cnf': 2,         # require classification confidence of 2 or more
+ #'iterations':10,  # iterate the fit
+#  't0': '2019-05-02T02:12:24',  # time range (not needed in this case)
+#  't1': '2019-05-02T03:00:00',
+#  'poly': poly,   # polygon within which to select photons, 
+}
+
+# YAPC alternatibe
+params_yapc={'srt': 1,
+ 'len': 20,
+ 'ats':3,
+ 'res':10,
+ 'track': 0,
+ 'pass_invalid': True,
+ 'cnf': -2,
+ 'iterations':10,}
+#  't0': '2019-05-02T02:12:24',
+#  't1': '2019-05-02T03:00:00',
+#     #   "yapc": dict(knn=0, win_h=6, win_x=11, min_ph=4, score=100),  # use the YAPC photon classifier; these are the recommended parameters, but the results might be more specific with a smaller win_h value, or a higher score cutoff
+#   "yapc": dict(knn=0, win_h=3, win_x=11, min_ph=4, score=50),  # use the YAPC photon classifier; these are the recommended parameters, but the results might be more specific with a smaller win_h value, or a higher score cutoff
+#  'poly':poly}
+
+
+# add domain
+params['poly'] = poly_test
+params['t0'] = '2019-05-01T00:00:00'
+params['t1'] = '2019-05-30T00:00:00'
+#params['t1'] = '2019-06-10T00:00:00'
+
+# get granuale list
+release = '005'
+granules_list = icesat2.cmr(polygon=params['poly'] , time_start=params['t0'], time_end=params['t1'], version=release)
+
+# %% download data
+gdf = icesat2.atl06p(params, asset="nsidc-s3", resources=granules_list)
+
+
+# %%
+
+
+# make q two panel figure, on the left plot the photon postions, on the the hoffmoeller diagram
+fig, axx = plt.subplots(1,3, figsize=(14,4))
+
+# sample data
+gdf2 = gdf.sample(n=12000, replace=False, random_state=1)
+
+ax = axx[0]
+ax.set_title("ATL Points")
+ax.set_aspect('equal')
+# FIX THIS TO SHOW EACH RGT value by color
+gdf2.plot(ax=ax, column='rgt', label='RGT', c=gdf2['rgt'], markersize= 0.5, cmap='winter')
+#ax.legend(loc="upper left")
+# Prepare coordinate lists for plotting the region of interest polygon
+region_lon = [e["lon"] for e in poly_test]
+region_lat = [e["lat"] for e in poly_test]
+ax.plot(region_lon, region_lat, linewidth=1, color='green');
+
+# labels
+ax.set_xlabel('Longitude')
+ax.set_ylabel('Latitude')
+
+# add a red dot for each 1st point in the RGT
+for rgt in gdf['rgt'].unique()[0:20]:
+    tmp = gdf[gdf['rgt']==rgt]
+    # 1st point
+    ax.plot(tmp.iloc[0].geometry.x, tmp.iloc[0].geometry.y, 'rv', markersize= 5, label='RGT')
+    # last point
+    ax.plot(tmp.iloc[-1].geometry.x, tmp.iloc[-1].geometry.y, 'ks', markersize= 5, label='RGT')
+    # line between first and last
+    if sct.ascending_test_distance(tmp):
+        axx[1].plot(tmp.geometry.x.mean(), tmp.index.mean(), 'ko', markersize= 5, label='ascending')
+        ax.plot([tmp.iloc[0].geometry.x, tmp.iloc[-1].geometry.x], [tmp.iloc[0].geometry.y, tmp.iloc[-1].geometry.y], '-', color='black', linewidth=1)
+
+    else:
+        axx[1].plot( tmp.geometry.x.mean(), tmp.index.mean(), 'o', color ='orange', markersize= 5, zorder=10, label='decending')
+        ax.plot([tmp.iloc[0].geometry.x, tmp.iloc[-1].geometry.x], [tmp.iloc[0].geometry.y, tmp.iloc[-1].geometry.y], '-', color='orange', linewidth=2.5)
+
+plt.legend()
+
+ax = axx[1]
+
+ax.plot(gdf2.geometry.x , gdf2.index, '.', markersize=0.5)
+# add labels
+ax.set_xlabel('Longitude')
+ax.set_ylabel('time')
+
+
+ax = axx[2]
+for rgt in gdf['rgt'].unique():
+    tmp = gdf2[gdf2['rgt']==rgt]
+
+    ax.plot(tmp['distance'], tmp['h_mean'],'.k', markersize=0.5)
+
+# vertical line with min_eq_dist
+
+plt.ylim(list(tmp['h_mean'].quantile([0.01, 0.99])))
+min_eq_dist = sct.get_min_eq_dist(poly_test)
+ax.axvline(min_eq_dist, color='red', linewidth=1, label= 'lower boundary')
+
+plt.ylabel('height')
+plt.xlabel('Distance from Equator')
+plt.legend()
+plt.show()
+
+# %%
+RGT_common = sct.check_RGT_in_domain(Gtrack_lowest, gdf)
+# %%
+imp.reload(sct)
+
+for rgt in RGT_common[0:2]:
+    tmp = gdf2[gdf2['rgt']==rgt]
+    start_point_dist, start_point = sct.define_reference_distance_with_RGT(Gtrack_lowest, rgt, sct.ascending_test_distance(tmp))
+    fig, axx = sct.plot_reference_point_coordinates(tmp, start_point_dist, start_point)
+
+
+# %% main routine for defining the x coordinate and sacing table data
+
+def make_B01_dict(table_data, split_by_beam=True):
+    """
+    converts a GeoDataFrame from Sliderule to GeoDataFrames for each beam witht the correct columns and names
+    inputs:
+        table_data: GeoDataFrame with the data
+        split_by_beam: True/False. If True the data is split by beam
+    returns:
+        if split_by_beam:
+            table_data: dict of GeoDataFrame with the data for each beam
+        else:
+            table_data: GeoDataFrame with the data for all beams in one table
+    """
+    #table_data = copy.copy(B01b_atl06_native)
+
+    table_data.rename(columns= {
+                        'n_fit_photons':'N_photos',
+                        'w_surface_window_final':'signal_confidence',
+                        'across':'y', 
+                        #'spot':'beam',
+                        }
+                        , inplace=True)
+
+    table_data['lons'] = table_data['geometry'].x
+    table_data['lats'] = table_data['geometry'].y
+
+    table_data.drop(columns=['cycle','gt','rgt', 'pflags'], inplace=True)
+
+    if split_by_beam:
+        B01b = dict()
+        # this is not tested
+        for spot,beam in zip([1,2,3, 4, 5, 6],['gt1l', 'gt1r', 'gt2l', 'gt2r', 'gt3l', 'gt3r']) : 
+            ii = table_data.spot==spot
+            B01b[beam] = table_data[ii]
+        return B01b
+    else:
+        return table_data
+
+
+T= dict()
+for rgt in RGT_common:
+    tmp = gdf[gdf['rgt']==rgt]
+    # if ascending_test(tmp):
+    #     print('ascending, set x to distance from first point')
+    # else:
+    #     print('descending, set x to distance from last point')
+
+    # define reference point and then define 'x'
+    table_data = copy.copy(tmp)
+
+    # the reference point is defined as the most equatorward point of the polygon. 
+    # It's distance from the equator is  subtracted from the distance of each photon.
+    table_data = sct.define_x_coordinate_with_RGT(table_data, Gtrack_lowest)
+
+    # fake 'across'
+    table_data['across'] = table_data['x']*0 +table_data['spot']
+
+    # add spike remover
+
+    #Tbeam = make_B01_dict(table_data, split_by_beam=True  )
+    # Tbeam['gt1r'][0:500].plot(markersize=0.5)
+
+    # renames columns and splits beams
+    T[rgt] = make_B01_dict(table_data, split_by_beam=True)
+
+#rgt
+
+# %% testing is re-referenceing worked
+plt.figure()    
+
+for ki,Ti in T.items():
+    #Ti['gt1r'].x.plot(x='x', y='h_mean', label=ki, markersize=0.5)
+    for kii,Tii in Ti.items():
+        try:
+            Tiis= Tii.sample(n=1000, replace=False, random_state=1)
+
+            accending_color= 'black' if sct.ascending_test_distance(Tiis) else 'red'
+            plt.plot(Tiis.geometry.x, Tiis.geometry.y, '.', markersize=0.5, label=kii, c= accending_color, alpha=0.3)
+            #plt.plot(Tiis.geometry.x, Tiis['x'], '.', markersize=0.5, label=kii, c= accending_color, alpha=0.3)
+            #plt.plot(Tiis['x'], Tiis.geometry.y , '.', markersize=0.5, label=kii, c= accending_color, alpha=0.3)
+
+        except:
+            #print('error with ', ki, kii)
+            pass
+plt.xlabel('x')
+plt.ylabel('Latitude')
+plt.grid()
+plt.show()
+
+
+# %%

--- a/SlideRule/S04_kml_orbits_to_geopandas_trials.py
+++ b/SlideRule/S04_kml_orbits_to_geopandas_trials.py
@@ -1,0 +1,153 @@
+# %%
+import os, sys
+
+"""
+This
+"""
+exec(open(os.environ["PYTHONSTARTUP"]).read())
+exec(open(STARTUP_2021_IceSAT2).read())
+
+
+from ICEsat2_SI_tools.read_ground_tracks import *
+# %%
+file  = '/Users/Shared/Projects/2021_ICESat2_tracks/data/groundtracks/originals/IS2_RGTs_cycle20_date_time.zip'
+#file='/Users/Shared/Projects/2021_ICESat2_tracks/data/originals/IS2_RGTs_cycle20_date_time.zip'
+G = read_ICESat2_groundtrack(file)
+G[G['RGT']=='1'].plot()
+
+G.plot(markersize=0.4)
+
+# %%
+G1 = G[G['RGT']=='1001']
+G1 = G1[G1.geometry.y>0]
+G1[0:-1].plot(markersize=1, linestyle='solid')
+G1[1::].plot(markersize=1, marker='+')
+
+plt.figure()
+Gdist = G1[0:-1].reset_index().geometry.distance(G1[1::].reset_index().geometry)
+Gdist.plot.hist()
+#G1[1::].reset_index().geometry
+print(Gdist.sum())
+#Gdist.median()*93
+#G2.plot.hist()
+plt.show()
+# %%
+plt.figure()
+
+Gdist.cumsum().plot()
+plt.show()
+# %%
+plt.figure()
+plt.plot(G1.geometry.y)
+plt.show()
+
+r = float(mconfig['constants']['radius'])
+2 *np.pi*r/1e3
+
+420*G1.shape[0]
+# %%
+
+file2 = '/Users/Shared/Projects/2021_ICESat2_tracks/data/groundtracks/originals/ICESat2_groundtracks_EasternHem.zip'
+G = read_ICESat2_groundtrack(file2)
+
+
+# %%
+
+file  = '/Users/Shared/Projects/2021_ICESat2_tracks/data/groundtracks/originals/IS2_RGTs_cycle20_date_time.zip'
+#file='/Users/Shared/Projects/2021_ICESat2_tracks/data/originals/IS2_RGTs_cycle20_date_time.zip'
+G = ICESat2_mission_groundtrack(file)
+# G[G['RGT']=='1'].plot()
+
+# %%
+# %%
+
+load_path ='/Users/Shared/Projects/2021_ICESat2_tracks/data/groundtracks/originals/'
+save_path ='/Users/Shared/Projects/2021_ICESat2_tracks/data/groundtracks/'
+
+#for filename, hemis in zip(['arcticallorbits.zip' , 'antarcticaallorbits.zip'], ['NH', 'SH'] ):
+for filename, hemis in zip(['ICESat2_groundtracks_EasternHem_small.zip' , 'ICESat2groundtracksWesternHem.zip'], ['EAST', 'WEST'] ):
+
+
+    loadfile  = load_path + filename
+    save_basename = 'IS2_mission_points_'+hemis+'_RGT_'
+
+    G = ICESat2_mission_points(loadfile)
+    G[ (G['GT']=='GT7')].to_file(save_path+save_basename +'all.shp')
+
+
+# plotting tests
+# G7[::500].plot(markersize=0.5)
+# G7[::500].geometry.to_crs(epsg=6931).plot(markersize=0.5)
+
+
+# %%
+
+# save individual tracks
+# def save_RGT_data(RGT, G, save_path, base_name):
+#     G2 = G[(G['RGT']==RGT)]
+#     G2.to_file(save_path+base_name+str(RGT).zfill(4)+'.shp')
+#     return RGT
+
+# for RGT in G7.RGT.unique():
+#     save_RGT_data(RGT, G7, save_path ,save_basename )
+
+# plotting examples
+# G2.geometry.plot(markersize=0.5)
+# plt.show()
+# G2.geometry.to_crs(epsg=6931).plot(markersize=0.5)
+# plt.axis('equal')
+
+
+# %%
+
+load_path ='/Users/Shared/Projects/2021_ICESat2_tracks/data/groundtracks/originals/ICESat2_groundtracks_EasternHem_small/'
+
+flist = os.listdir(load_path)
+
+#def ICESat2_mission_points2(input_file):
+input_file = loadfile
+# decompress and parse KMZ file
+input_file = pathlib.Path(input_file).expanduser().absolute()
+kmzs = zipfile.ZipFile(str(input_file), 'r')
+parser = lxml.etree.XMLParser(recover=True, remove_blank_text=True)
+# for each kml in the zipfile (per GT)
+GTs = []
+# %%
+# for kmz in kmzs.filelist:
+#     kmls = zipfile.ZipFile(kmzs.open(kmz, 'r'))
+for kml in flist:
+    tree = lxml.etree.parse(kml, parser)
+    root = tree.getroot()
+    # find documents within kmz file
+    for document in root.iterfind('.//kml:Document', root.nsmap):
+        # extract laser name, satellite track and coordinates of line strings
+        name = document.find('name', root.nsmap).text
+        placemarks = document.findall('Placemark/name', root.nsmap)
+        coords = document.findall('Placemark/LineString/coordinates', root.nsmap)
+        # create list of rows
+        rows = []
+        x = []; y = []
+        # for each set of coordinates
+        for i,c in enumerate(coords):
+            # create a line string of coordinates
+            line = np.array([x.split(',')[:2] for x in c.text.split()], dtype='f8')
+            for ln,lt in zip(line[:,0], line[:,1]):
+                columns = {}
+                columns['Laser'], = re.findall(r'laser(\d+)', name)
+                columns['GT'], = re.findall(r'GT\d[LR]?', kmz.filename)
+                columns['RGT'] = int(placemarks[i].text)
+                rows.append(columns)
+                x.append(ln)
+                y.append(lt)
+        # create geopandas geodataframe for points
+        gdf = geopandas.GeoDataFrame(rows,
+            geometry=geopandas.points_from_xy(x,y)
+        )
+        GTs.append(gdf)
+# return the concatenated and georefernced geodataframe
+G = geopandas.pd.concat(GTs)
+G.geometry.crs = {'init': 'epsg:4326'}
+#return G
+
+#G = ICESat2_mission_points2(loadfile)
+# %%

--- a/SlideRule/S05_RGT_polygon_intersect.py
+++ b/SlideRule/S05_RGT_polygon_intersect.py
@@ -1,0 +1,136 @@
+# %%
+import os, sys
+
+"""
+This file open a ICEsat2 track applied filters and corections and returns smoothed photon heights on a regular grid in an .nc file.
+This is python 3.11
+"""
+exec(open(os.environ["PYTHONSTARTUP"]).read())
+exec(open(STARTUP_2021_IceSAT2).read())
+
+# import sys
+# import logging
+# import concurrent.futures
+# import time
+# from datetime import datetime
+# import pandas as pd
+import geopandas as gpd
+# import matplotlib.pyplot as plt
+# from pyproj import Transformer, CRS
+from shapely.geometry import Polygon, Point
+from sliderule import icesat2
+from sliderule import sliderule
+# import re
+# import datetime
+import numpy as np
+import shapely
+
+import matplotlib
+
+from ipyleaflet import basemaps, Map, GeoData
+
+import ICEsat2_SI_tools.convert_GPS_time as cGPS
+import h5py
+import ICEsat2_SI_tools.io as io
+import ICEsat2_SI_tools.spectral_estimates as spec
+import ICEsat2_SI_tools.lanczos as lanczos
+
+from ICEsat2_SI_tools.read_ground_tracks import *
+
+import imp
+import copy
+import spicke_remover
+import generalized_FT as gFT
+xr.set_options(display_style='text')
+
+
+#matplotlib.use('agg')
+# %matplotlib inline
+# %matplotlib widget
+
+
+plot_path = mconfig['paths']['plot'] +'sliderule_tests/'
+MT.mkdirs_r(plot_path)
+
+
+# %% Select region and retrive batch of tracks
+
+# create boundary based on given track information
+# latR  = [np.round(ID['pars']['start']['latitude'], 1), np.round(ID['pars']['end']['latitude'], 1) ]
+# lonR  = [np.round(ID['pars']['start']['longitude'], 1), np.round(ID['pars']['end']['longitude'], 1) ]
+
+ground_track_length = 20160 #km
+
+latR = [-67.2, -64.3]
+lonR = [140.0, 145.0]
+
+latR = [25.0, 30.0]
+lonR = [140.0, 150.0]
+
+latR = [65.0, 75.0]
+lonR = [140.0, 160.0]
+
+latR.sort()
+lonR.sort()
+
+poly_test=[{'lat':latR[ii], 'lon':lonR[jj]} for ii, jj in zip([1, 1, 0, 0, 1], [1, 0, 0, 1, 1])]
+print('new ', latR, lonR)
+
+
+# %% Load RGT data
+
+polygon = make_plot_polygon(poly_test)
+polygon_shapely= Polygon([(item['lon'], item['lat']) for item in poly_test])
+
+
+# %% 
+load_path_RGT = '/Users/Shared/Projects/2021_ICESat2_tracks/data/groundtracks/'
+G = gpd.read_file(load_path_RGT + 'IS2_mission_points_NH_RGT_all.shp') #mask=polygon_shapely)
+
+# %%
+Gs = gpd.read_file(load_path_RGT + 'IS2_mission_points_NH_RGT_all.shp', mask=polygon_shapely)
+
+
+# %% plot polygon and data
+m = plot_polygon(poly_test, basemap=basemaps.Esri.WorldImagery, zoom=3)
+#m.add_layer(polygon_shapely, c ='red')
+geo_data = GeoData(geo_dataframe = Gs[::5],
+    #style={'color': 'red', 'radius':1},
+    point_style={'radius': 0.1, 'color': 'red', 'fillOpacity': 0.1},
+    name = 'rgt')
+m.add_layer(geo_data)
+m
+# %%
+
+G_lowest = get_RGT_start_points(Gs)
+G_highest = get_RGT_end_points(Gs)
+
+# %%
+fig, axx = plt.subplots(1,1, figsize=(4,4))
+
+ax = axx
+ax.set_title("ATL Points")
+
+# FIX THIS TO SHOW EACH RGT value by color
+#G_lowest.plot(ax=ax, column='RGT', label='RGT', c=G_lowest['RGT'], markersize= 5, cmap='winter')
+
+G_lowest[0:10].plot(ax=ax, label='RGT', c='red', markersize= 10)
+G_highest[0:10].plot(ax=ax, label='RGT', c='black', markersize= 10)
+
+for rgt in Gs['RGT'].unique()[0:10]:
+    Gs[Gs['RGT'] == rgt].plot(ax=ax, c='blue', markersize= 0.8, alpha= 0.6)
+
+#ax.legend(loc="upper left")
+# Prepare coordinate lists for plotting the region of interest polygon
+region_lon = [e["lon"] for e in poly_test]
+region_lat = [e["lat"] for e in poly_test]
+ax.plot(region_lon, region_lat, linewidth=1, color='gray');
+
+# labels
+ax.set_xlabel('Longitude')
+ax.set_ylabel('Latitude')
+ax.set_aspect('equal')
+# %% Define intersect with the 65deg N/S as distance=0
+
+# find lon/lat coodinates intersect with the 65N/S lattiude 
+G

--- a/SlideRule/S06_SL_dem_h_and_stats.py
+++ b/SlideRule/S06_SL_dem_h_and_stats.py
@@ -1,0 +1,130 @@
+# %%
+"""
+This file open a ICEsat2 track applied filters and corections and returns smoothed photon heights on a regular grid in an .nc file.
+This is python 3.11
+"""
+import os, sys
+exec(open(os.environ["PYTHONSTARTUP"]).read())
+exec(open(STARTUP_2021_IceSAT2).read())
+
+import geopandas as gpd
+
+from sliderule import sliderule, icesat2, earthdata
+
+import shapely
+from ipyleaflet import basemaps, Map, GeoData
+
+import ICEsat2_SI_tools.sliderule_converter_tools as sct
+import ICEsat2_SI_tools.io as io
+import ICEsat2_SI_tools.beam_stats as beam_stats
+
+import spicke_remover
+
+import h5py, imp, copy
+import datetime
+
+
+xr.set_options(display_style='text')
+
+# %matplotlib inline
+# %matplotlib widget
+
+
+# Select region and retrive batch of tracks
+
+track_name, batch_key, ID_flag = io.init_from_input(sys.argv) # loads standard experiment
+# define file with ID:
+track_name, batch_key , ID_flag = '20190219073735_08070210_005_01', 'SH_testSLsinglefile2' , False
+#track_name, batch_key , ID_flag = '20190219075059_08070212_005_01', 'SH_testSLsinglefile2' , False
+#track_name, batch_key , ID_flag = '20190502052058_05180312_005_01', 'SH_testSLsinglefile2' , False
+
+#track_name, batch_key , ID_flag = '20190504201233_05580312_005_01', 'SH_testSLsinglefile2' , False
+
+
+#20190502052058_05180312_005_01
+plot_flag = True
+hemis = batch_key.split('_')[0]
+#plot_path   = mconfig['paths']['plot'] + '/'+hemis+'/'+batch_key+'/' + track_name +'/'
+
+save_path  = mconfig['paths']['work'] +'/'+batch_key+'/B01_regrid/'
+MT.mkdirs_r(save_path)
+
+save_path_json  = mconfig['paths']['work'] +'/'+ batch_key +'/A01b_ID/'
+MT.mkdirs_r(save_path_json)
+
+#ID, _, _, _ = io.init_data(track_name, batch_key, True, mconfig['paths']['work'],  )
+ATL03_track_name = 'ATL03_'+track_name+'.h5'
+#track_name = ID['tracks']['ATL03'][0] +'.h5'
+
+# %% Configure SL Session #
+sliderule.authenticate("brown", ps_username="mhell", ps_password="Oijaeth9quuh")
+icesat2.init("slideruleearth.io", organization="brown", desired_nodes=1, time_to_live=90) #minutes
+
+
+# %% plot the ground tracks in geographic location
+# Generate ATL06-type segments using the ATL03-native photon classification
+# Use the ocean classification for photons with a confidence parmeter to 2 or higher (low confidence or better)
+
+params={'srt': 1,  # Ocean classification
+ 'len': 25,        # 10-meter segments
+ 'ats':3,          # require that each segment contain photons separated by at least 5 m
+ 'res':10,         # return one photon every 10 m
+ 'dist_in_seg': False, # if False units of len and res are in meters
+ 'track': 0,       # return all ground tracks
+ 'pass_invalid': False,    
+ 'cnt': 5,
+ 'sigma_r_max': 5,  # maximum standard deviation of photon in extend
+ 'cnf': 2,         # require classification confidence of 2 or more
+ 'atl03_geo_fields' : ['dem_h']
+ }
+
+
+# YAPC alternatibe
+params_yapc={'srt': 1,
+ 'len': 20,
+ 'ats':3,
+ 'res':10,
+ 'dist_in_seg': False, # if False units of len and res are in meters 
+ 'track': 0,
+ 'pass_invalid': False,
+ 'cnf': 2,
+ 'cnt': 5,
+ 'maxi':10,
+ 'yapc': dict(knn=0, win_h=6, win_x=11, min_ph=4, score=100), # use the YAPC photon classifier; these are the recommended parameters, but the results might be more specific with a smaller win_h value, or a higher score cutoff
+#   "yapc": dict(knn=0, win_h=3, win_x=11, min_ph=4, score=50),  # use the YAPC photon classifier; these are the recommended parameters, but the results might be more specific with a smaller win_h value, or a higher score cutoff
+'atl03_geo_fields' : ['dem_h']
+} 
+gdf = icesat2.atl06p(params, resources=[ATL03_track_name])
+
+# %%
+
+imp.reload(sct)
+#gdf[::100].plot(markersize=0.1, figsize=(4,6))
+
+G = gdf.copy()#[gdf['spot'] == 1]
+
+#G[::100].plot(markersize=0.2)
+
+G2 = sct.correct_and_remove_height(G, 30)#.plot(markersize=0.2)
+G2[::100].plot(markersize=0.2)
+#Gc['h_mean'].plot(marker='.')
+#G2['spot'].unique()
+
+
+# %%
+cdict = dict()
+for s,b in zip(G2['spot'].unique(), ['gt1l', 'gt1r', 'gt2l', 'gt2r', 'gt3l', 'gt3r']):
+    cdict[s] = col.rels[b]
+
+imp.reload(beam_stats)
+
+#G2['h_mean_gradient'] = G2['h_mean'].diff()
+
+font_for_pres()
+F = M.figure_axis_xy(6.5, 5, view_scale=0.6)
+F.fig.suptitle('title')
+
+beam_stats.plot_ATL06_track_data(G2, cdict)
+
+
+# %%

--- a/analysis_db/A02b_WW3_hindcast_prior.py
+++ b/analysis_db/A02b_WW3_hindcast_prior.py
@@ -1,4 +1,4 @@
-
+# %%
 import os, sys
 #execfile(os.environ['PYTHONSTARTUP'])
 
@@ -38,6 +38,11 @@ track_name, batch_key, ID_flag = io.init_from_input(sys.argv) # loads standard e
 #track_name, batch_key, ID_flag = 'NH_20190301_09600205', 'NH_batch05', True
 
 #track_name, batch_key, ID_flag = 'NH_20210228_10231005', 'NH_batch07', True
+
+#track_name, batch_key, test_flag = 'SH_20190219_08070210', 'SH_publish', True 
+
+#track_name, batch_key, test_flag = 'SH_20190219_08070210', 'SH_testSLsinglefile2', True 
+
 track_name_short = track_name[0:-16]
 
 ID, track_names, hemis, batch = io.init_data(track_name, batch_key, ID_flag, mconfig['paths']['work'] )
@@ -68,6 +73,7 @@ file_name_base      = 'LOPS_WW3-GLOB-30M_'
 load_path   = mconfig['paths']['work'] +batch_key+'/B01_regrid/'
 #Gd          = io.load_pandas_table_dict(track_name + '_B01_binned' , load_path)  #
 Gd          = h5py.File(load_path +'/'+track_name + '_B01_binned.h5', 'r')
+
 
 # %%
 G1 = dict()
@@ -113,7 +119,10 @@ else:
 
 # load .json to get time
 #ID['tracks']['ATL07'].split('_')[1]
-timestamp       = pd.to_datetime(ID['tracks']['ATL07'].split('_')[1])
+
+
+#timestamp       = pd.to_datetime(ID['tracks']['ATL03'].split('_')[1])
+timestamp       = pd.to_datetime(ID['pars']['start']['delta_time'], unit='s')
 #timestamp       = pd.to_datetime(G1[['year', 'month', 'day', 'hour', 'minute', 'second']]).mean()
 time_range      = np.datetime64(timestamp) - np.timedelta64(dtime, 'h') , np.datetime64(timestamp) + np.timedelta64(dtime, 'h')
 #print(time_range)
@@ -419,3 +428,5 @@ except:
     target_name = 'A02_'+track_name+'hindcast_fail'
 
 MT.json_save(target_name, save_path, str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M")) )
+
+# %%

--- a/analysis_db/A02c_IOWAGA_thredds_prior.py
+++ b/analysis_db/A02c_IOWAGA_thredds_prior.py
@@ -1,0 +1,442 @@
+
+# %%
+import os, sys
+#execfile(os.environ['PYTHONSTARTUP'])
+
+"""
+
+"""
+
+exec(open(os.environ['PYTHONSTARTUP']).read())
+exec(open(STARTUP_2021_IceSAT2).read())
+
+#%matplotlib inline
+
+import ICEsat2_SI_tools.convert_GPS_time as cGPS
+import h5py
+import ICEsat2_SI_tools.io as io
+import ICEsat2_SI_tools.spectral_estimates as spec
+import ICEsat2_SI_tools.wave_tools as waves
+
+from siphon.catalog import TDSCatalog
+
+
+import imp
+import copy
+import spicke_remover
+import datetime
+import concurrent.futures as futures
+#import s3fs
+
+col.colormaps2(21)
+
+# %%
+track_name, batch_key, ID_flag = io.init_from_input(sys.argv) # loads standard experiment
+#track_name, batch_key, test_flag = '20190605061807_10380310_004_01', 'SH_batch01', False
+#track_name, batch_key, test_flag = '20190601094826_09790312_004_01', 'SH_batch01', False
+#track_name, batch_key, test_flag = '20190207111114_06260210_004_01', 'SH_batch02', False
+#track_name, batch_key, test_flag = '20190219073735_08070210_004_01', 'SH_batch02', False
+#track_name, batch_key, test_flag = '20190217194220_07840212_004_01', 'SH_batch02', False
+#track_name, batch_key, test_flag = '20190219073735_08070210_004_01', 'SH_batch02', False
+#track_name, batch_key, ID_flag = 'NH_20190301_09600205', 'NH_batch05', True
+
+#track_name, batch_key, ID_flag = 'NH_20210228_10231005', 'NH_batch07', True
+
+#track_name, batch_key, test_flag = 'SH_20190219_08070210', 'SH_publish', True 
+
+#track_name, batch_key, test_flag = 'SH_20190219_08070210', 'SH_testSLsinglefile2', True 
+#track_name, batch_key , test_flag = 'SH_20190502_05180312', 'SH_testSLsinglefile2' , True
+
+
+track_name_short = track_name[0:-16]
+
+ID, track_names, hemis, batch = io.init_data(track_name, batch_key, ID_flag, mconfig['paths']['work'] )
+
+#print(track_name, batch_key, test_flag)
+hemis, batch = batch_key.split('_')
+#track_name= '20190605061807_10380310_004_01'
+ATlevel= 'ATL03'
+
+save_path   = mconfig['paths']['work'] + batch_key+'/A02_prior/'
+plot_path   = mconfig['paths']['plot'] + '/'+hemis+'/'+batch_key+'/' + track_name + '/'
+save_name   = 'A02_'+track_name
+plot_name    = 'A02_'+track_name_short
+MT.mkdirs_r(plot_path)
+MT.mkdirs_r(save_path)
+bad_track_path =mconfig['paths']['work'] +'bad_tracks/'+ batch_key+'/'
+# %%
+
+all_beams   = mconfig['beams']['all_beams']
+high_beams  = mconfig['beams']['high_beams']
+low_beams   = mconfig['beams']['low_beams']
+#Gfilt   = io.load_pandas_table_dict(track_name + '_B01_regridded', load_path) # rhis is the rar photon data
+
+load_path_WAVE_GLO  = mconfig['paths']['work'] +'/GLOBMULTI_ERA5_GLOBCUR_01/'
+file_name_base      = 'LOPS_WW3-GLOB-30M_'
+
+
+load_path   = mconfig['paths']['work'] +batch_key+'/B01_regrid/'
+#Gd          = io.load_pandas_table_dict(track_name + '_B01_binned' , load_path)  #
+Gd          = h5py.File(load_path +'/'+track_name + '_B01_binned.h5', 'r')
+
+
+# %%
+G1 = dict()
+for b in all_beams:
+    # find 1st point
+    Gi  = io.get_beam_hdf_store(Gd[b])
+    G1[b] = Gi.iloc[abs(Gi['lats']).argmin()]
+
+Gd.close()
+G1 = pd.DataFrame.from_dict(G1).T
+
+
+if hemis == 'SH':
+
+    # DEFINE SEARCH REGION AND SIZE OF BOXES FOR AVERAGES
+    dlon_deg = 1 # degree range aroud 1st point
+    dlat_deg = 30, 5 # degree range aroud 1st point
+    dlat_deg_prior = 2, 1 # degree range aroud 1st point
+
+    dtime = 4 # in hours
+
+    lon_range       = G1['lons'].min() - dlon_deg , G1['lons'].max() + dlon_deg
+    lat_range       = np.sign(G1['lats'].min())*78 , G1['lats'].max() + dlat_deg[1]
+    lat_range_prior = G1['lats'].min() - dlat_deg_prior[0] , G1['lats'].max() + dlat_deg_prior[1]
+
+else:
+    # DEFINE SEARCH REGION AND SIZE OF BOXES FOR AVERAGES
+    dlon_deg = 2            # lon degree range aroud 1st point
+    dlat_deg = 20, 20        # lat degree range aroud 1st point
+    dlat_deg_prior = 2, 1   # degree range aroud 1st point
+
+    dtime = 4 # in hours
+
+    #ID['pars']['end']
+    lon_range       = G1['lons'].min() - dlon_deg , G1['lons'].max() + dlon_deg
+    lat_range       = G1['lats'].min() - dlat_deg[0] , G1['lats'].max() + dlat_deg[1]
+    lat_range_prior = G1['lats'].min() - dlat_deg_prior[0] , G1['lats'].max() + dlat_deg_prior[1]
+
+    # lon_range       = ID['pars']['start']['longitude'] - dlon_deg , ID['pars']['start']['longitude'] + dlon_deg
+    # lat_range       = ID['pars']['start']['latitude']  - dlat_deg[0] , ID['pars']['start']['latitude'] + dlat_deg[1]
+    # lat_range_prior = ID['pars']['start']['latitude'] - dlat_deg_prior[0] , ID['pars']['start']['latitude'] + dlat_deg_prior[1]
+
+
+# load .json to get time
+#ID['tracks']['ATL07'].split('_')[1]
+
+
+#timestamp       = pd.to_datetime(ID['tracks']['ATL03'].split('_')[1])
+timestamp       = pd.to_datetime(ID['pars']['start']['delta_time'], unit='s')
+#timestamp       = pd.to_datetime(G1[['year', 'month', 'day', 'hour', 'minute', 'second']]).mean()
+time_range      = np.datetime64(timestamp) - np.timedelta64(dtime, 'h') , np.datetime64(timestamp) + np.timedelta64(dtime, 'h')
+#print(time_range)
+
+## load WW3 data
+# ECMWF hindcast
+# data_url = 'https://tds3.ifremer.fr/thredds/IOWAGA-WW3-HINDCAST/IOWAGA-GLOBAL_ECMWF-WW3-HINDCAST_FULL_TIME_SERIE.xml'
+
+# CFSR hindcast
+# data_url = 'https://tds3.ifremer.fr/thredds/IOWAGA-WW3-HINDCAST/IOWAGA-GLOBAL_CFSR-WW3-HINDCAST_FULL_TIME_SERIE.xml'
+
+# ECMWF forecast
+data_url = 'https://tds3.ifremer.fr/thredds/IOWAGA-WW3-FORECAST/IOWAGA-WW3-FORECAST_GLOBMULTI_GLOB-30M.xml'
+
+cat = TDSCatalog(data_url)
+
+#ncss = cat.datasets['IOWAGA-GLOBAL_ECMWF-WW3-HINDCAST Full Time Serie'].remote_access(use_xarray=True)
+#ncss = cat.datasets['IOWAGA-GLOBAL_CFSR-WW3-HINDCAST Full Time Serie'].remote_access(use_xarray=True)
+ncss = cat.datasets['IOWAGA-WW3-FORECAST_GLOBMULTI_GLOB-30M_FIELD_NC_MARC_WW3-GLOB-30M'].remote_access(use_xarray=True)
+
+
+
+# %%
+var_list = [ 'dir', 'dp','fp', 'hs', 'ice', 'spr',
+'t01', 't02', #'t0m1', 'tws',
+'plp0', 
+'pdir0',  'pdir1',  'pdir2',  'pdir3',  'pdir4',  'pdir5',
+'pspr0',  'pspr1',  'pspr2',  'pspr3',  'pspr4',  'pspr5',
+'ptp0',  'ptp1',  'ptp2',  'ptp3',  'ptp4',  'ptp5',
+'phs0',  'phs1',  'phs2',  'phs3',  'phs4',  'phs5']
+
+
+# chunk data
+IOWAGA = ncss[var_list]
+IOWAGA['time'] = np.array([np.datetime64(k0) for k0 in IOWAGA.time.data]).astype('M8[h]')
+IOWAGA = IOWAGA.rename(name_dict= { 'pdir0': 'pdp0',  'pdir1': 'pdp1',  'pdir2': 'pdp2',  'pdir3': 'pdp3',  'pdir4': 'pdp4', 'pdir5': 'pdp5'})#, inplace=True)
+
+
+
+# %%
+
+def sel_data(I, lon_range, lat_range, timestamp = None):
+    """
+    this method returns the selected data in the lon-lat box at an interpolated timestamp
+    """
+    lon_flag = (lon_range[0] < I.longitude.data) & (I.longitude.data < lon_range[1])
+    lat_flag = (lat_range[0] < I.latitude.data) & (I.latitude.data < lat_range[1])
+    time_flag = (time_range[0] < I.time.data) & (I.time.data < time_range[1])
+    if timestamp is None:
+        I = I.isel(latitude = lat_flag, longitude = lon_flag)
+    else:
+        I = I.isel(latitude = lat_flag, longitude = lon_flag, time=time_flag).sortby('time').interp(time=np.datetime64(timestamp))
+    return I
+
+    #I = I.isel(latitude = lat_flag, longitude = lon_flag)
+
+try:
+    # load file and load WW# data
+    G_beam  = sel_data(IOWAGA     , lon_range, lat_range      , timestamp).load()
+    G_prior = sel_data(G_beam   , lon_range, lat_range_prior)
+
+
+    if hemis == 'SH':
+        # % create Ice mask
+        ice_mask = (G_beam.ice > 0) | np.isnan(G_beam.ice)
+
+        #G1.mean()['lats']
+        # mask_at_points = (ice_mask.sum('longitude') == ice_mask.shape[1]).sel(latitude =slice(G1['lats'].min(), G1['lats'].max()))
+        # if (mask_at_points.sum().data == mask_at_points.size):
+        #     print('all points in ice mask')
+        #     lat_range_prior
+        #     lat_range_prior = lat_range_prior, lat_range_prior[1] + 2
+        #ice_mask.sel(latitude=G1.mean()['lats'], longitude =G1.mean()['lons'], method ='nearest')
+
+        # mask all latitudes that are completely full with sea ice.
+        lats = list(ice_mask.latitude.data)
+        lats.sort(reverse= True)
+        #(ice_mask.sum('longitude') == ice_mask.longitude.size).sel(latitude = lats)
+
+        # find 1st latitude that is completely full with sea ice.
+        ice_lat_pos = next((i for i, j in enumerate(  (ice_mask.sum('longitude') == ice_mask.longitude.size).sel(latitude = lats)) if j), None)
+        # recreate lat mask based on this criteria
+        lat_mask = lats < lats[ice_lat_pos]
+        lat_mask = xr.DataArray( lat_mask.repeat(ice_mask.longitude.size ).reshape(ice_mask.shape), dims = ice_mask.dims, coords = ice_mask.coords )
+        lat_mask['latitude'] =lats
+
+        # combine ice mask and new lat mask
+        ice_mask = ice_mask + lat_mask
+
+    else:
+        ice_mask =np.isnan(G_beam.ice)
+
+        #G_beam.hs.sum('longitude').plot()
+        lats = ice_mask.latitude
+        #lats.sort(reverse= True)
+
+
+        # find closed latituyde with with non-nan data
+        ice_lat_pos = abs(lats.where(ice_mask.sum('longitude') > 4, np.nan) - np.array(lat_range).mean()).argmin().data
+
+        #redefine lat-range
+        lat_range       = lats[ice_lat_pos].data  - 2 , lats[ice_lat_pos].data + 2
+        lat_flag2 = (lat_range[0] < lats.data) & (lats.data < lat_range[1])
+        # find 1st latitude that has non-zero HS .
+        #ice_lat_pos = next((i for i, j in enumerate(  (G_beam.hs.sum('longitude') != 0).sel(latitude = lats)) if j), None)
+        # recreate lat mask based on this criteria
+        #lat_mask = lats < lats[ice_lat_pos]
+        lat_mask = xr.DataArray( lat_flag2.repeat(ice_mask.longitude.size ).reshape(ice_mask.shape), dims = ice_mask.dims, coords = ice_mask.coords )
+        lat_mask['latitude'] =lats
+
+        # combine ice mask and new lat mask
+        #ice_mask = ~lat_mask
+
+
+    # plot 1st figure
+    def draw_range(lon_range, lat_range, *args, **kargs):
+        plt.plot( [lon_range[0], lon_range[1], lon_range[1], lon_range[0], lon_range[0]] , [lat_range[0], lat_range[0], lat_range[1], lat_range[1], lat_range[0]] , *args, **kargs)
+
+    dir_clev= np.arange(0, 380, 20)
+    f_clev = np.arange(1/40, 1/5, 0.01)
+    fvar = ['ice',          'dir',                   'dp',       'spr',      'fp',    'hs']
+    fcmap =[plt.cm.Blues_r, col.circle_medium_triple, col.circle_medium_triple, plt.cm.Blues, plt.cm.Blues, plt.cm.Blues  ]
+    fpos = [0, 1, 2, 3, 4, 5]
+    clevs = [np.arange(0, 1, 0.2), dir_clev,           dir_clev,                 np.arange(0, 90, 10), f_clev, np.arange(.5, 9, 0.5) ]
+
+
+    font_for_print()
+    #plt.rc('pcolor', shading = 'auto')
+    F = M.figure_axis_xy(4, 3.5, view_scale= 0.9, container = True)
+    plt.suptitle(track_name_short + ' | ' +file_name_base[0:-1].replace('_', ' '), y = 1.3)
+    lon, lat= G_beam.longitude, G_beam.latitude
+
+    gs = GridSpec(9,6,  wspace=0.1,  hspace=0.4)#figure=fig,
+    #pos0,pos1,pos2 = gs[0:3, 0],gs[3, 0],gs[4, 0]#,gs[3, 0]
+
+    for fv, fp, fc, cl in zip(fvar, fpos, fcmap, clevs):
+
+        ax1 = F.fig.add_subplot(gs[0:7, fp]) #plt.subplot(1, 6, fp)
+        if fp ==0:
+            ax1.spines['bottom'].set_visible(False)
+            ax1.spines['left'].set_visible(False)
+            ax1.tick_params(labelbottom=True, bottom=True)
+
+        else:
+            ax1.axis('off')
+
+        plt.plot(G1['lons'], G1['lats'], '.r', markersize=5)
+        draw_range(lon_range, lat_range_prior, c='red', linewidth = 1, zorder=12)
+        draw_range(lon_range, lat_range, c='blue', linewidth = 0.7, zorder=10)
+        #G_beam.ice.plot(cmap=plt.cm.Blues_r, )
+        if fv != 'ice':
+            #.where(~ice_mask, np.nan)
+            cm = plt.pcolor(lon, lat,G_beam[fv], vmin=cl[0], vmax=cl[-1] , cmap=fc)
+            if G_beam.ice.shape[0] > 1:
+                plt.contour(lon, lat,G_beam.ice, colors= 'black', linewidths = 0.6)
+        else:
+            cm =plt.pcolor(lon, lat,G_beam[fv], vmin=cl[0], vmax=cl[-1],  cmap=fc)
+
+        #plt.title(fv, loc='center')
+        plt.title(G_beam[fv].long_name.replace(' ', '\n') +'\n'+ fv, loc='left')
+        ax1.axis('equal')
+
+        ax2 = F.fig.add_subplot(gs[-1, fp]) #plt.subplot(1, 6, fp)
+        #plt.axis('off')
+        cbar = plt.colorbar(cm, cax= ax2, orientation = 'horizontal', aspect= 1, fraction=1)
+        cl_ticks = np.linspace(cl[0], cl[-1] , 3)
+
+        cbar.set_ticks(  np.round( cl_ticks, 3) )
+        #[str(i) for i in np.round( cl_ticks, 1)  ]
+        cbar.set_ticklabels(  np.round( cl_ticks, 2))
+
+    F.save_pup(path= plot_path, name =plot_name+'_hindcast_data')
+
+    # % derive prior:
+    #G_beam_masked['dir']
+    G_beam_masked = G_beam.where(~ice_mask, np.nan)
+    ice_mask_prior = ice_mask.sel(latitude=G_prior.latitude)
+    G_prior_masked = G_prior.where(~ice_mask_prior, np.nan)
+
+
+    def test_nan_frac(imask):
+        "test if False is less then 0.3"
+        return ((~imask).sum()/imask.size).data < 0.3
+
+    while test_nan_frac(ice_mask_prior):
+        print(lat_range_prior)
+        lat_range_prior = lat_range_prior[0] + 0.5, lat_range_prior[1] + 0.5
+        G_prior = sel_data(G_beam  , lon_range, lat_range_prior)
+        ice_mask_prior = ice_mask.sel(latitude=G_prior.latitude)
+
+    G_prior_masked = G_prior.where(~ice_mask_prior, np.nan)
+
+    ### make pandas table with obs track end postitions
+
+    key_list = list(G_prior_masked.keys())
+    # define directional and amplitude pairs
+    # pack as  (amp, angle)
+    key_list_pairs = {
+        'mean': ( 'hs', 'dir'),
+        'peak': ( 'hs', 'dp'),
+        'partion0': ('phs0', 'pdp0'),
+        'partion1': ('phs1', 'pdp1'),
+        'partion2': ('phs2', 'pdp2'),
+        'partion3': ('phs3', 'pdp3'),
+        'partion4': ('phs4', 'pdp4') }
+
+
+    key_list_pairs2 =list()
+    for k in key_list_pairs.values():
+        key_list_pairs2.append(k[0])
+        key_list_pairs2.append(k[1])
+
+    key_list_scaler = set(key_list) - set(key_list_pairs2)
+
+
+    ### derive angle avearge
+    Tend = pd.DataFrame(index =key_list, columns = ['mean', 'std', 'name'] )
+
+    for k, pair in key_list_pairs.items():
+        ave_amp, ave_deg, std_amp, std_deg = waves.get_ave_amp_angle(G_prior_masked[pair[0]].data, G_prior_masked[pair[1]].data)
+        Tend.loc[pair[0]] = ave_amp, std_amp, G_prior_masked[pair[0]].long_name
+        Tend.loc[pair[1]] = ave_deg, std_deg, G_prior_masked[pair[1]].long_name
+        #key_list_pairs[k] = {pair[0]:ave_amp, pair[1]:ave_deg }
+
+    for k in key_list_scaler:
+        Tend.loc[k] = G_prior_masked[k].mean().data, G_prior_masked[k].std().data, G_prior_masked[k].long_name
+
+
+    Tend = Tend.T
+    Tend['lon'] = [ice_mask_prior.longitude.mean().data ,ice_mask_prior.longitude.std().data , 'lontigude']
+    Tend['lat'] = [ice_mask_prior.latitude[ice_mask_prior.sum('longitude') ==0].mean().data ,ice_mask_prior.latitude[ice_mask_prior.sum('longitude') ==0].std().data , 'latitude']
+    Tend = Tend.T
+
+    Prior = dict()
+    Prior['incident_angle'] = {'value': Tend['mean']['dp'].astype('float') , 'name': Tend['name']['dp']}
+    Prior['spread']         = {'value': Tend['mean']['spr'].astype('float') , 'name': Tend['name']['spr']}
+    Prior['Hs']             = {'value': Tend['mean']['hs'].astype('float') , 'name': Tend['name']['hs']}
+    Prior['peak_period']    = {'value': 1/Tend['mean']['fp'].astype('float') , 'name': '1/' +Tend['name']['fp']}
+
+    Prior['center_lon'] = {'value': Tend['mean']['lon'].astype('float') , 'name': Tend['name']['lon']}
+    Prior['center_lat'] = {'value': Tend['mean']['lat'].astype('float') , 'name': Tend['name']['lat']}
+
+    target_name = 'A02_'+track_name+'_hindcast_success'
+
+    MT.save_pandas_table({'priors_hindcast':Tend}, save_name, save_path)
+except:
+    target_name = 'A02_'+track_name+'_hindcast_fail'
+
+# %%
+def plot_prior(Prior, axx):
+    angle = Prior['incident_angle']['value'] # incident direction in degrees from North clockwise (Meerological convention)
+    # use
+    angle_plot = - angle -90
+    axx.quiver(Prior['center_lon']['value'], Prior['center_lat']['value'],  - np.cos( angle_plot *np.pi/180), - np.sin( angle_plot *np.pi/180) , scale=4.5, zorder =12, width=0.1 ,headlength = 4.5, minshaft=2, alpha = 0.6, color = 'black' )
+    axx.plot(Prior['center_lon']['value'], Prior['center_lat']['value'] , '.', markersize= 6, zorder =12, alpha = 1, color = 'black' )
+    tstring=  ' ' +str(np.round(  Prior['peak_period']['value'], 1) )+'sec \n ' +  str( np.round(Prior['Hs']['value'], 1) )+'m\n ' + str(np.round(angle, 1)) +'deg'
+    plt.text(lon_range[1], Prior['center_lat']['value'], tstring)
+
+
+try:
+    # plot 2nd figure
+
+    font_for_print()
+    F = M.figure_axis_xy(2, 4.5, view_scale= 0.9, container = False)
+
+    ax1 = F.ax
+    lon, lat= G_beam.longitude, G_beam.latitude
+    #gs = GridSpec(1,6,  wspace=0.1,  hspace=0.4)#figure=fig,
+    #pos0,pos1,pos2 = gs[0:3, 0],gs[3, 0],gs[4, 0]#,gs[3, 0]
+    ax1.spines['bottom'].set_visible(False)
+    ax1.spines['left'].set_visible(False)
+    ax1.tick_params(labelbottom=True, bottom=True)
+
+    plot_prior(Prior, ax1)
+
+    str_list = list()
+    for i in np.arange(0, 6):
+        str_list.append(' ' + str(np.round(Tend.loc['ptp'+str(i)]['mean'], 1)) +'sec\n ' + str(np.round(Tend.loc['phs'+str(i)]['mean'], 1)) +'m '+str(np.round(Tend.loc['pdp'+str(i)]['mean'], 1))+'d')
+
+    plt.text(lon_range[1], lat_range[0], '\n '.join(str_list) )
+
+    for vv in zip(['pdp0','pdp1','pdp2','pdp3','pdp4','pdp5'],['phs0','phs1','phs3','phs4','phs5']) :
+
+        angle_plot = - Tend.loc[vv[0]]['mean'] -90
+        vsize = (1/Tend.loc[vv[1]]['mean'])**(1/2) *5
+        print(vsize)
+        ax1.quiver(Prior['center_lon']['value'], Prior['center_lat']['value'],  - np.cos( angle_plot *np.pi/180), - np.sin( angle_plot *np.pi/180) , scale=vsize, zorder =5, width=0.1 ,headlength = 4.5, minshaft=4, alpha = 0.6, color = 'green' )
+
+    plt.plot(G1['lons'], G1['lats'], '.r', markersize=5)
+    draw_range(lon_range, lat_range_prior, c='red', linewidth = 1, zorder=11)
+    draw_range(lon_range, lat_range, c='blue', linewidth = 0.7, zorder=10)
+
+    #G_beam.ice.plot(cmap=plt.cm.Blues_r, )
+    fv ='ice'
+    if fv != 'ice':
+        plt.pcolor(lon, lat,G_beam[fv].where(~ice_mask, np.nan), cmap=fc)
+        plt.contour(lon, lat,G_beam.ice, colors= 'black', linewidths = 0.6)
+    else:
+        plt.pcolor(lon, lat,G_beam[fv], cmap=fc)
+
+    #plt.title(fv, loc='center')
+    plt.title('Prior\n' + file_name_base[0:-1].replace('_', ' ') +'\n'+ track_name_short + '\nIncident angle', loc='left')
+    ax1.axis('equal')
+
+
+    F.save_pup(path= plot_path, name =plot_name+'_hindcast_prior')
+except:
+    print('print 2nd figure failed')
+
+MT.json_save(target_name, save_path, str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M")) )
+
+print('done')

--- a/analysis_db/B01_SL_load_batch.py
+++ b/analysis_db/B01_SL_load_batch.py
@@ -121,7 +121,7 @@ if plot_flag:
 
 def make_B01_dict(table_data, split_by_beam=True, to_hdf5=False):
     """
-    converts a GeoDataFrame from Sliderule to GeoDataFrames for each beam witht the correct columns and names
+    converts a GeoDataFrame from Sliderule to GeoDataFrames for each beam with the correct columns and names
     inputs:
         table_data: GeoDataFrame with the data
         split_by_beam: True/False. If True the data is split by beam

--- a/analysis_db/B01_SL_load_batch.py
+++ b/analysis_db/B01_SL_load_batch.py
@@ -36,6 +36,8 @@ batch_key = 'SH_testSL'
 save_path  = mconfig['paths']['work'] +'/'+batch_key+'/B01_regrid/'
 MT.mkdirs_r(save_path)
 
+save_path_json = mconfig['paths']['work'] +'/'+ batch_key +'/A01b_ID/'
+
 # %% Configure SL Session #
 icesat2.init("slideruleearth.io", True) 
 asset = 'nsidc-s3'
@@ -43,7 +45,7 @@ asset = 'nsidc-s3'
 # %% Select region and retrive batch of tracks
 
 # Southern Hemisphere test
-latR, lonR = [-67.2, -64.3], [140.0, 155.0]
+latR, lonR = [-67.2, -62], [140.0, 155.0]
 
 # Northern Hemisphere test
 #latR, lonR = [65.0, 75.0], [140.0, 155.0]
@@ -159,11 +161,66 @@ def make_B01_dict(table_data, split_by_beam=True, to_hdf5=False):
     else:
         return table_data
 
+
+def get_box_latitude_extend(poly):
+    "return in meters the latitude extend of the polygon"
+    return sct.haversine(0, abs(min(poly['lats'])), 0, abs(max(poly['lats'])) ) *1e3
+
+def get_Nmax(poly, resolution):
+    "returns maximum number of bins in the y direction"
+    return np.round(get_box_latitude_extend(poly) / resolution ).astype(int)
+
+
+def create_search_string(track,  cycle):
+    "create search string for granule list"
+    track = str(track).zfill(4)
+    cycle = str(cycle).zfill(2)
+    return '_' + track + cycle 
+
+
+def format_density_table(D_b_size, resolution):
+    "format density table"
+    D_size_mean  = pd.concat(D_b_size, axis=1)/get_Nmax(poly, resolution)
+    D_size_mean.loc['mean'] = D_size_mean.mean(0)
+    D_size_mean.loc['no_data'] = (D_size_mean == 0).sum(0)
+    D_size_mean = D_size_mean.round(2)
+    D_size_mean.loc['no_data'] = D_size_mean.T['no_data'].astype(int)
+
+    D_size_mean.name = 'Datapoint Fraction'
+    return D_size_mean.T
+
+def save_table_as_pdf(formatted_table, save_path, name):
+    import pandas as pd
+    import matplotlib.pyplot as plt
+    # Generate a PNG image of the table using matplotlib
+    F = M.figure_axis_xy(10, 5)# figsize=(10, 10))
+    ax = F.ax #plt.subplots()
+    ax.axis('off')
+    ax.axis('tight')
+    the_table = ax.table(cellText=formatted_table.values, colLabels=formatted_table.columns, rowLabels =formatted_table.index, loc='center', fontsize=24)
+
+    the_table.auto_set_font_size(False)
+    #the_table.set_fontsize(14)
+
+    F.fig.savefig(save_path+ '/'+ name + '.pdf')
+
+
+beam_list = ['gt1l', 'gt1r', 'gt2l', 'gt2r', 'gt3l', 'gt3r']
+# b_size = [Ti[k].size for k in beam_list]
+# b_Nmedian = [Ti[k].N_photos.median() for k in beam_list]
+
+
 imp.reload(sct)
 
 T= dict()
+
+D_b_size = dict()
+D_b_Nmedian = dict()
+D_name = dict()
+D_track = dict()
 for rgt in RGT_common:
     tmp = gdf[gdf['rgt']==rgt]
+
 
     # define reference point and then define 'x'
     table_data = copy.copy(tmp)
@@ -184,8 +241,40 @@ for rgt in RGT_common:
 
     ID_name = sct.create_ID_name(tmp.iloc[0])
     print( ID_name )
-    io.write_track_to_HDF5(Ti, ID_name + '_B01_binned'     , save_path) # regridding heights
+
+    #io.write_track_to_HDF5(Ti, ID_name + '_B01_binned'     , save_path) # regridding heights
+
+    # save stats
+    D_b_size[rgt] = pd.Series( [Ti[k].shape[0] for k in beam_list], name = rgt)
+    D_b_Nmedian[rgt] = pd.Series( [Ti[k].N_photos.median() for k in beam_list], name = rgt)
+
+    D_name[rgt] = ID_name
+    # search for granule in granule list
+    search_string = create_search_string(rgt, gdf.cycle.unique()[0])
+    D_track[rgt] = [g for g in granules_list if search_string in g][0]
+
+print('save Granule list to file')
+#granules_list
+
+#MT.json_save2(name='B01_SL_batch_granule_list', path=save_path_json, data= granules_list)
 
 
+print('format tables ')
+
+D_name = pd.Series(D_name, name='ID_name')
+D_track = pd.Series(D_track, name='granule')
+
+D_size_mean = format_density_table(D_b_size, resolution=params['res'])
+D_size_mean = pd.concat([D_size_mean, D_track , D_name ], axis=1)
+D_size_mean.sort_values('mean', ascending=False).to_html(save_path_json + batch_key + '_point_density.html')
+
+D_b_Nmedian = pd.concat(D_b_Nmedian, axis=1)
+D_b_Nmedian.index = beam_list
+D_b_Nmedian = pd.concat([D_b_Nmedian.T, D_track , D_name ], axis=1)
+D_b_Nmedian.to_html(save_path_json + batch_key + '_photon_density.html')
+
+
+#.to_html(save_path_json + batch_key + '_point_density_sorted.html')
 print('done')
+
 # %%

--- a/analysis_db/B01_SL_load_single_file.py
+++ b/analysis_db/B01_SL_load_single_file.py
@@ -152,6 +152,8 @@ Ti = make_B01_dict(table_data, split_by_beam=True, to_hdf5=True)
 
 for kk in Ti.keys():
     Ti[kk]['dist'] = Ti[kk]['x'].copy()
+    Ti[kk]['heights_c_weighted_mean'] = Ti[kk]['h_mean'].copy()
+    Ti[kk]['heights_c_std'] = Ti[kk]['h_sigma'].copy()
 
 #Ti[kk]['dist'] = Ti[kk]['x'].copy()
 #Ti['gt1l'].drop('geometry', axis=1, inplace=True)

--- a/analysis_db/B01_SL_load_single_file.py
+++ b/analysis_db/B01_SL_load_single_file.py
@@ -29,7 +29,7 @@ xr.set_options(display_style='text')
 # %matplotlib widget
 
 
-# %% Select region and retrive batch of tracks
+# Select region and retrive batch of tracks
 
 # define file with ID:
 track_name, batch_key , ID_flag = '20190219073735_08070210_005_01', 'SH_testSLsinglefile' , False

--- a/analysis_db/B01_SL_load_single_file.py
+++ b/analysis_db/B01_SL_load_single_file.py
@@ -10,14 +10,14 @@ exec(open(STARTUP_2021_IceSAT2).read())
 
 import geopandas as gpd
 
-from sliderule import icesat2
-from sliderule import sliderule
+from sliderule import sliderule, icesat2, earthdata
 
 import shapely
 from ipyleaflet import basemaps, Map, GeoData
 
 import ICEsat2_SI_tools.sliderule_converter_tools as sct
 import ICEsat2_SI_tools.io as io
+import ICEsat2_SI_tools.beam_stats as beam_stats
 
 import spicke_remover
 
@@ -36,14 +36,16 @@ xr.set_options(display_style='text')
 track_name, batch_key, ID_flag = io.init_from_input(sys.argv) # loads standard experiment
 # define file with ID:
 #track_name, batch_key , ID_flag = '20190219073735_08070210_005_01', 'SH_testSLsinglefile2' , False
+#track_name, batch_key , ID_flag = '20190219075059_08070212_005_01', 'SH_testSLsinglefile2' , False
 #track_name, batch_key , ID_flag = '20190502052058_05180312_005_01', 'SH_testSLsinglefile2' , False
 
-track_name, batch_key , ID_flag = '20190504201233_05580312_005_01', 'SH_testSLsinglefile2' , False
+#track_name, batch_key , ID_flag = '20190504201233_05580312_005_01', 'SH_testSLsinglefile2' , False
 
 
 #20190502052058_05180312_005_01
 plot_flag = True
-
+hemis = batch_key.split('_')[0]
+#plot_path   = mconfig['paths']['plot'] + '/'+hemis+'/'+batch_key+'/' + track_name +'/'
 
 save_path  = mconfig['paths']['work'] +'/'+batch_key+'/B01_regrid/'
 MT.mkdirs_r(save_path)
@@ -56,8 +58,9 @@ ATL03_track_name = 'ATL03_'+track_name+'.h5'
 #track_name = ID['tracks']['ATL03'][0] +'.h5'
 
 # %% Configure SL Session #
-icesat2.init("slideruleearth.io", True) 
-asset = 'nsidc-s3'
+sliderule.authenticate("brown", ps_username="mhell", ps_password="Oijaeth9quuh")
+icesat2.init("slideruleearth.io", organization="brown", desired_nodes=1, time_to_live=90) #minutes
+
 
 # %% plot the ground tracks in geographic location
 # Generate ATL06-type segments using the ATL03-native photon classification
@@ -67,27 +70,53 @@ params={'srt': 1,  # Ocean classification
  'len': 25,        # 10-meter segments
  'ats':3,          # require that each segment contain photons separated by at least 5 m
  'res':10,         # return one photon every 10 m
+ 'dist_in_seg': False, # if False units of len and res are in meters
  'track': 0,       # return all ground tracks
- 'pass_invalid': True,   
+ 'pass_invalid': False,    
+ 'cnt': 20,
+ 'sigma_r_max': 4,  # maximum standard deviation of photon in extend
  'cnf': 2,         # require classification confidence of 2 or more
- #'iterations':10,  # iterate the fit
-}
+ 'atl03_geo_fields' : ['dem_h']
+ }
+
 
 # YAPC alternatibe
 params_yapc={'srt': 1,
  'len': 20,
  'ats':3,
  'res':10,
+ 'dist_in_seg': False, # if False units of len and res are in meters 
  'track': 0,
- 'pass_invalid': True,
- 'cnf': -2,
- 'iterations':10,}
-#     #   "yapc": dict(knn=0, win_h=6, win_x=11, min_ph=4, score=100),  # use the YAPC photon classifier; these are the recommended parameters, but the results might be more specific with a smaller win_h value, or a higher score cutoff
+ 'pass_invalid': False,
+ 'cnf': 2,
+ 'cnt': 20,
+ 'sigma_r_max': 4,  # maximum standard deviation of photon in extend
+ 'maxi':10,
+ 'yapc': dict(knn=0, win_h=6, win_x=11, min_ph=4, score=100), # use the YAPC photon classifier; these are the recommended parameters, but the results might be more specific with a smaller win_h value, or a higher score cutoff
 #   "yapc": dict(knn=0, win_h=3, win_x=11, min_ph=4, score=50),  # use the YAPC photon classifier; these are the recommended parameters, but the results might be more specific with a smaller win_h value, or a higher score cutoff
+'atl03_geo_fields' : ['dem_h']
+} 
 
-gdf = icesat2.atl06p(params, asset="nsidc-s3", resources=[ATL03_track_name])
+maximum_height = 30 # (meters) maximum height past dem_h correction 
 
-gdf.plot()
+gdf = icesat2.atl06p(params_yapc, resources=[ATL03_track_name])
+gdf = sct.correct_and_remove_height(gdf, maximum_height)#.plot(markersize=0.2)
+
+
+# %%
+cdict = dict()
+for s,b in zip(gdf['spot'].unique(), ['gt1l', 'gt1r', 'gt2l', 'gt2r', 'gt3l', 'gt3r']):
+    cdict[s] = col.rels[b]
+
+#imp.reload(beam_stats)
+
+font_for_pres()
+F_atl06 = M.figure_axis_xy(6.5, 5, view_scale=0.6)
+F_atl06.fig.suptitle(track_name)
+
+beam_stats.plot_ATL06_track_data(gdf, cdict)
+
+
 # %% main routine for defining the x coordinate and sacing table data
 
 def make_B01_dict(table_data, split_by_beam=True, to_hdf5=False):
@@ -107,7 +136,8 @@ def make_B01_dict(table_data, split_by_beam=True, to_hdf5=False):
     table_data.rename(columns= {
                         'n_fit_photons':'N_photos',
                         'w_surface_window_final':'signal_confidence',
-                        'across':'y', 
+                        'y_atc':'y',
+                        'x_atc': 'distance',  
                         #'spot':'beam',
                         }
                         , inplace=True)
@@ -142,7 +172,7 @@ table_data.drop(columns=['time'], inplace=True)
 #table_data['time'] = np.datetime_as_string(table_data['time'])#.view('<M8[s]')
 
 # fake 'across'
-table_data['across'] = table_data['x']*0 +table_data['spot']
+#table_data['across'] = table_data['y_atc']*0 +table_data['spot']
 
 #table_data['time'].astype('<S30').view('<M8[s]')
 # add spike remover
@@ -163,7 +193,41 @@ ID_name = sct.create_ID_name(gdf.iloc[0], segment=segment)
 print( ID_name )
 io.write_track_to_HDF5(Ti, ID_name + '_B01_binned'     , save_path) # regridding heights
 
+# %% plot the ground tracks in geographic location
 
+all_beams   = mconfig['beams']['all_beams']
+high_beams  = mconfig['beams']['high_beams']
+low_beams   = mconfig['beams']['low_beams']
+
+D  = beam_stats.derive_beam_statistics(Ti, all_beams, Lmeter=12.5e3, dx =10)
+
+# %%
+
+# save figure from above:
+plot_path   = mconfig['paths']['plot'] + '/'+hemis+'/'+batch_key+'/' + ID_name +'/'
+MT.mkdirs_r(plot_path)
+F_atl06.save_light(path = plot_path , name = 'B01b_ATL06_corrected.png')
+plt.close()
+
+imp.reload(beam_stats)
+if plot_flag:
+
+    font_for_pres()
+    F = M.figure_axis_xy(8, 4.3, view_scale= 0.6  )
+    beam_stats.plot_beam_statistics(D, high_beams, low_beams, col.rels, track_name = track_name + '|  ascending =' + str(sct.ascending_test_distance(gdf)) )
+
+    F.save_light(path = plot_path , name = 'B01b_beam_statistics.png')
+    plt.close()
+
+    # plot the ground tracks in geographic location
+    gdf[::100].plot(markersize=0.1, figsize=(4,6))
+    plt.title(track_name +  '\nascending =' + str(sct.ascending_test_distance(gdf)) , loc ='left')
+    # gdf_atl03 = icesat2.atl03s(params, [ATL03_track_name])
+    M.save_anyfig(plt.gcf(), path = plot_path  ,name = 'B01_track.png')
+    # gdf_atl03.plot()
+    plt.close()
+
+    
 
 
 # %%
@@ -182,12 +246,12 @@ end_pos = abs(table_data.lats).argmax()
 DD['pars'] ={
 'poleward': sct.ascending_test(gdf), 'region': '0',
 'start': {'longitude': table_data.lons[start_pos], 'latitude': table_data.lats[start_pos]
-, 'seg_dist_x': table_data.x[start_pos]
+, 'seg_dist_x': float(table_data.x[start_pos])
 , 'delta_time': datetime.datetime.timestamp(table_time[start_pos])
  #'0'#np.datetime64(table_data.index[end_pos]) #table_data.index[start_pos]
 },
 'end': {'longitude': table_data.lons[end_pos], 'latitude': table_data.lats[end_pos]
-, 'seg_dist_x': table_data.x[end_pos]
+, 'seg_dist_x': float(table_data.x[end_pos])
 , 'delta_time': datetime.datetime.timestamp(table_time[end_pos])
  #table_data.index[end_pos]
 },

--- a/analysis_db/B01_SL_load_single_file.py
+++ b/analysis_db/B01_SL_load_single_file.py
@@ -38,6 +38,9 @@ track_name, batch_key, ID_flag = io.init_from_input(sys.argv) # loads standard e
 #track_name, batch_key , ID_flag = '20190219073735_08070210_005_01', 'SH_testSLsinglefile2' , False
 #track_name, batch_key , ID_flag = '20190502052058_05180312_005_01', 'SH_testSLsinglefile2' , False
 
+track_name, batch_key , ID_flag = '20190504201233_05580312_005_01', 'SH_testSLsinglefile2' , False
+
+
 #20190502052058_05180312_005_01
 plot_flag = True
 
@@ -146,6 +149,11 @@ table_data['across'] = table_data['x']*0 +table_data['spot']
 
 # renames columns and splits beams
 Ti = make_B01_dict(table_data, split_by_beam=True, to_hdf5=True) 
+
+for kk in Ti.keys():
+    Ti[kk]['dist'] = Ti[kk]['x'].copy()
+
+#Ti[kk]['dist'] = Ti[kk]['x'].copy()
 #Ti['gt1l'].drop('geometry', axis=1, inplace=True)
 
 segment = track_name.split('_')[1][-2:]

--- a/analysis_db/B01b_SL_plot_track_var.py
+++ b/analysis_db/B01b_SL_plot_track_var.py
@@ -1,0 +1,125 @@
+# %%
+import os, sys
+#execfile(os.environ['PYTHONSTARTUP'])
+
+"""
+This file open a ICEsat2 track applied filters and corections and returns smoothed photon heights on a regular grid in an .nc file.
+This is python 3
+"""
+
+exec(open(os.environ['PYTHONSTARTUP']).read())
+exec(open(STARTUP_2021_IceSAT2).read())
+
+#%matplotlib inline
+from threadpoolctl import threadpool_info, threadpool_limits
+from pprint import pprint
+
+
+import ICEsat2_SI_tools.convert_GPS_time as cGPS
+import h5py
+import ICEsat2_SI_tools.io as io
+import ICEsat2_SI_tools.spectral_estimates as spec
+
+import time
+import imp
+import copy
+import spicke_remover
+import datetime
+import generalized_FT as gFT
+from scipy.ndimage.measurements import label
+
+# from guppy import hpy
+# h=hpy()
+# h.heap()
+#import s3fs
+#from memory_profiler import profile
+import tracemalloc
+
+def linear_gap_fill(F, key_lead, key_int):
+
+    """
+    F pd.DataFrame
+    key_lead   key in F that determined the independent coordindate
+    key_int     key in F that determined the dependent data
+    """
+    y_g = np.array(F[key_int])
+
+    nans, x2= np.isnan(y_g), lambda z: z.nonzero()[0]
+    y_g[nans]= np.interp(x2(nans), x2(~nans), y_g[~nans])
+
+    return y_g
+
+
+# %%
+track_name, batch_key, test_flag = io.init_from_input(sys.argv) # loads standard experiment
+#track_name, batch_key, test_flag = '20190605061807_10380310_004_01', 'SH_batch01', False
+#track_name, batch_key, test_flag = '20190601094826_09790312_004_01', 'SH_batch01', False
+#track_name, batch_key, test_flag = '20190207111114_06260210_004_01', 'SH_batch02', False
+#track_name, batch_key, test_flag = '20190208152826_06440210_004_01', 'SH_batch01', False
+#track_name, batch_key, test_flag = '20190213133330_07190212_004_01', 'SH_batch02', False
+#track_name, batch_key, test_flag = '20190205231558_06030212_004_01', 'SH_batch02', False
+
+#local track
+#track_name, batch_key, test_flag = '20190219073735_08070210_004_01', 'SH_batch02', False
+#track_name, batch_key, test_flag = 'NH_20190301_09580203', 'NH_batch05', False
+
+#track_name, batch_key, test_flag = 'NH_20190301_09590203', 'NH_batch05', False
+#track_name, batch_key, test_flag = 'SH_20190101_00630212', 'SH_batch04', False
+#track_name, batch_key, test_flag = 'NH_20190301_09570205',  'NH_batch05', True
+#track_name, batch_key, test_flag = 'SH_20190219_08070212',  'SH_publish', True
+
+#track_name, batch_key, test_flag = 'NH_20190302_09830203',  'NH_batch06', True
+
+#track_name, batch_key, test_flag = 'SH_20190219_08070210', 'SH_batchminimal', True 
+
+#track_name, batch_key , test_flag = 'SH_20190219_08070210', 'SH_testSLsinglefile2' , True
+#track_name, batch_key , test_flag = 'SH_20190502_05180312', 'SH_testSLsinglefile2' , True
+#track_name, batch_key , test_flag = 'SH_20190502_05180312', 'SH_testSLsinglefile2' , True
+
+
+#print(track_name, batch_key, test_flag)
+hemis, batch = batch_key.split('_')
+#track_name= '20190605061807_10380310_004_01'
+ATlevel= 'ATL03'
+
+load_path   = mconfig['paths']['work'] + '/'+ batch_key +'/B01_regrid/'
+load_file   = load_path + 'processed_' + ATlevel + '_' + track_name + '.h5'
+
+save_path   = mconfig['paths']['work'] + '/'+ batch_key+ '/B02_spectra/'
+save_name   = 'B02_'+track_name
+
+plot_path   = mconfig['paths']['plot'] + '/'+hemis+'/'+batch_key+'/' + track_name 
+MT.mkdirs_r(plot_path)
+MT.mkdirs_r(save_path)
+bad_track_path =mconfig['paths']['work'] +'bad_tracks/'+ batch_key+'/'
+# %%
+
+all_beams   = mconfig['beams']['all_beams']
+high_beams  = mconfig['beams']['high_beams']
+low_beams   = mconfig['beams']['low_beams']
+#Gfilt   = io.load_pandas_table_dict(track_name + '_B01_regridded', load_path) # rhis is the rar photon data
+
+# laod with pandas
+#Gd      = io.load_pandas_table_dict(track_name + '_B01_binned' , load_path)  #
+
+# open with hdf5
+Gd = h5py.File(load_path +'/'+track_name + '_B01_binned.h5', 'r')
+#Gd.close()
+
+# %%
+imp.reload(beam_stats)
+
+import ICEsat2_SI_tools.beam_stats as beam_stats
+
+D  = beam_stats.derive_beam_statistics(Gd, all_beams, Lmeter=10e3, dx =10)
+
+font_for_pres()
+F = M.figure_axis_xy(6.5, 4, view_scale= 0.6  )
+beam_stats.plot_beam_statistics(D, high_beams, low_beams, col.rels, track_name = track_name)
+F.save_light(path = plot_path , name = 'B01b_beam_statistics.png')
+
+# print('saved and done')
+
+
+
+# %%

--- a/analysis_db/B03_plot_spectra_ov.py
+++ b/analysis_db/B03_plot_spectra_ov.py
@@ -405,7 +405,7 @@ MT.mkdirs_r(plot_path+'B03_spectra/')
 
 x_pos_sel =  np.arange(Gk.x.size)[~np.isnan(Gk.mean('beam').mean('k').gFT_PSD_data.data)]
 x_pos_max = Gk.mean('beam').mean('k').gFT_PSD_data[~np.isnan(Gk.mean('beam').mean('k').gFT_PSD_data)].argmax().data
-xpp = x_pos_sel[ [int(i) for i in np.round(np.linspace(0, x_pos_sel.size-1, 4))]]
+xpp = x_pos_sel[ [int(i) for i in np.round(np.linspace(0, x_pos_sel.size-1, 8))]]
 xpp = np.insert(xpp, 0, x_pos_max)
 
 for i in xpp:

--- a/analysis_db/B04_angle.py
+++ b/analysis_db/B04_angle.py
@@ -60,7 +60,8 @@ track_name, batch_key, test_flag = io.init_from_input(sys.argv) # loads standard
 #track_name, batch_key, test_flag = '20190210143705_06740210_004_01', 'SH_batch02', False
 #track_name, batch_key, test_flag = 'NH_20190301_09580203', 'NH_batch05', True
 #track_name, batch_key, test_flag = 'SH_20190210_06740210', 'SH_publish', True
-#track_name, batch_key, test_flag = 'SH_20190219_08070212', 'SH_batchminimal', True 
+#track_name, batch_key, test_flag = 'SH_20190219_08070212', 'SH_batchminimal', True
+track_name, batch_key , test_flag = 'SH_20190502_05180312', 'SH_testSLsinglefile2' , True
 
 
 
@@ -105,11 +106,14 @@ load_path   = mconfig['paths']['work'] +batch_key+'/A02_prior/'
 try:
     Prior = MT.load_pandas_table_dict('/A02_'+track_name, load_path)['priors_hindcast']
 except:
-    print('Prior not founds exit')
+    print('Prior not found. exit')
     MT.json_save('B04_fail', plot_path,  {'time':time.asctime( time.localtime(time.time()) ) , 'reason': 'Prior not found'})
-    print('exit()')
     exit()
 
+if np.isnan(Prior['mean']['dir']): 
+    print('Prior failed, entries are nan. exit.')
+    MT.json_save('B04_fail', plot_path,  {'time':time.asctime( time.localtime(time.time()) ) , 'reason': 'Prior not found'})
+    exit()
 
 #### Define Prior
 # Use partitions
@@ -816,3 +820,5 @@ plt.xlim(- 90, 90)
 F.save_pup(path= plot_path, name = 'B04_marginal_distributions')
 
 MT.json_save('B04_success', plot_path, {'time':'time.asctime( time.localtime(time.time()) )'})
+
+# %%

--- a/analysis_db/B06_correct_separate_var.py
+++ b/analysis_db/B06_correct_separate_var.py
@@ -1,4 +1,4 @@
-
+# %%
 import os, sys
 #execfile(os.environ['PYTHONSTARTUP'])
 
@@ -42,12 +42,12 @@ ID_name, batch_key, test_flag = io.init_from_input(sys.argv) # loads standard ex
 
 #ID_name, batch_key, test_flag =  'SH_20190208_06440212', 'SH_publish', True
 #ID_name, batch_key, test_flag =  'SH_20190219_08070210', 'SH_publish', True
-ID_name, batch_key, test_flag =  'SH_20190502_05160312', 'SH_publish', True
+#ID_name, batch_key, test_flag =  'SH_20190502_05160312', 'SH_publish', True
 
 #ID_name, batch_key, test_flag =  'NH_20190311_11200203', 'NH_batch06', True
 #ID_name, batch_key, test_flag =  'NH_20210312_11961005', 'NH_batch07', True
 
-
+#ID_name, batch_key , test_flag = 'SH_20190502_05180312', 'SH_testSLsinglefile2' , True
 
 #print(ID_name, batch_key, test_flag)
 hemis, batch = batch_key.split('_')
@@ -57,15 +57,16 @@ high_beams  = mconfig['beams']['high_beams']
 low_beams   = mconfig['beams']['low_beams']
 
 load_path_work    = mconfig['paths']['work'] +'/'+ batch_key +'/'
-B2_hdf5    = h5py.File(load_path_work +'B01_regrid'+'/'+ID_name + '_B01_regridded.h5', 'r')
 B3_hdf5    = h5py.File(load_path_work +'B01_regrid'+'/'+ID_name + '_B01_binned.h5', 'r')
 
-B2, B3 = dict(), dict()
+
+load_path_angle   = mconfig['paths']['work'] +'/'+ batch_key +'/B04_angle/'
+
+B3 = dict()
 for b in all_beams:
-    B2[b] = io.get_beam_hdf_store(B2_hdf5[b])
     B3[b] = io.get_beam_hdf_store(B3_hdf5[b])
 
-B2_hdf5.close(), B2_hdf5.close()
+B3_hdf5.close()
 
 # B2          = io.load_pandas_table_dict(ID_name + '_B01_regridded'  , load_path1) # rhis is the rar photon data
 # B3          = io.load_pandas_table_dict(ID_name + '_B01_binned'     , load_path1)  #
@@ -507,7 +508,7 @@ for pos, k, pflag in zip([gs[2:4, 0],gs[2:4, 1],gs[2:4, 2] ], low_beams, [True, 
 F.save_light(path=plot_path, name =str(ID_name) + '_B06_atten_ov_simple')
 F.save_pup(path=plot_path, name = str(ID_name) + '_B06_atten_ov_simple')
 
-# %%
+# %
 pos = gs[5:, 0:2]
 ax0 = F.fig.add_subplot(pos)
 
@@ -633,15 +634,15 @@ for bb in Gx.beam.data:
         dist_stencil_lims_plot = Gx_1.eta[0]*1 + Gx_1.x, Gx_1.eta[-1]*1 + Gx_1.x
 
         T3_sel              = B3[k].loc[( (B3[k]['dist']   >= dist_stencil_lims[0])    & (B3[k]['dist']    <= dist_stencil_lims[1])   )]
-        T2_sel              = B2[k].loc[(  B2[k]['x_true'] >= T3_sel['x_true'].min() ) & ( B2[k]['x_true'] <= T3_sel['x_true'].max()  )]
+        #T2_sel              = B2[k].loc[(  B2[k]['x_true'] >= T3_sel['x_true'].min() ) & ( B2[k]['x_true'] <= T3_sel['x_true'].max()  )]
 
         if T3_sel.shape[0] != 0:
-            if T3_sel['x_true'].iloc[-1] < T3_sel['x_true'].iloc[0]:
-                dist_T2_temp =np.interp(T2_sel['x_true'][::-1], T3_sel['x_true'][::-1],  T3_sel['dist'][::-1] )
-                T2_sel['dist']      = dist_T2_temp[::-1]
-            else:
-                dist_T2_temp =np.interp(T2_sel['x_true'], T3_sel['x_true'],  T3_sel['dist'] )
-                T2_sel['dist']      = dist_T2_temp
+            # if T3_sel['x_true'].iloc[-1] < T3_sel['x_true'].iloc[0]:
+            #     dist_T2_temp =np.interp(T2_sel['x_true'][::-1], T3_sel['x_true'][::-1],  T3_sel['dist'][::-1] )
+            #     T2_sel['dist']      = dist_T2_temp[::-1]
+            # else:
+            #     dist_T2_temp =np.interp(T2_sel['x_true'], T3_sel['x_true'],  T3_sel['dist'] )
+            #     T2_sel['dist']      = dist_T2_temp
 
             height_model, poly_offset, dist_nanmask = reconstruct_displacement(Gx_1, Gk_1, T3_sel, k_thresh = k_thresh)
             poly_offset = poly_offset*0
@@ -718,12 +719,12 @@ for bb in Gx.beam.data:
     continous_nans          = np.interp(continous_x_grid, concented_x, concented_nans ) ==1
 
     T3              = B3[bb]#.loc[( (B3[k]['dist']   >= dist_stencil_lims[0])    & (B3[k]['dist']    <= dist_stencil_lims[1])   )]
-    T2              = B2[bb]#.loc[(  B2[k]['x_true'] >= T3_sel['x_true'].min() ) & ( B2[k]['x_true'] <= T3_sel['x_true'].max()  )]
+    #T2              = B2[bb]#.loc[(  B2[k]['x_true'] >= T3_sel['x_true'].min() ) & ( B2[k]['x_true'] <= T3_sel['x_true'].max()  )]
 
-    T2 = T2.sort_values('x_true')
-    T3 = T3.sort_values('x_true')
-    T2['dist']    = np.interp(T2['x_true'], T3['x_true'],  T3['dist'] )
-    T2 = T2.sort_values('dist')
+    #T2 = T2.sort_values('x_true')
+    T3 = T3.sort_values('x')
+    #T2['dist']    = np.interp(T2['x_true'], T3['x_true'],  T3['dist'] )
+    #T2 = T2.sort_values('dist')
     T3 = T3.sort_values('dist')
 
     #T2              = T2.sort_index()
@@ -733,11 +734,11 @@ for bb in Gx.beam.data:
     T3['heights_c_model_err'] = np.interp(T3['dist'], continous_x_grid, concented_err)
     T3['heights_c_residual']  = T3['heights_c_weighted_mean'] - T3['heights_c_model']
 
-    T2['heights_c_model']     = np.interp(T2['dist'], continous_x_grid, continous_height_model)
-    T2['heights_c_residual']  = T2['heights_c'] - T2['heights_c_model']
+    #T2['heights_c_model']     = np.interp(T2['dist'], continous_x_grid, continous_height_model)
+    #T2['heights_c_residual']  = T2['heights_c'] - T2['heights_c_model']
 
 
-    B2_v2[bb] = T2
+    #B2_v2[bb] = T2
     B3_v2[bb] = T3
     Gx_v2[bb] = Gx_k
 
@@ -769,15 +770,15 @@ for bb in Gx.beam.data:
 
 # %% correct wave incident direction
 
-load_path = mconfig['paths']['work'] + '/B04_angle_'+hemis+'/'
+#load_path = mconfig['paths']['work'] + '/B04_angle/'
 
 try:
-    G_angle = xr.open_dataset(load_path+ '/B05_'+ID_name + '_angle_pdf.nc' )
+    G_angle = xr.open_dataset(load_path_angle+ '/B05_'+ID_name + '_angle_pdf.nc' )
 
     font_for_pres()
 
     Ga_abs = (G_angle.weighted_angle_PDF_smth.isel(angle = G_angle.angle > 0).data + G_angle.weighted_angle_PDF_smth.isel(angle = G_angle.angle < 0).data[:,::-1])/2
-    Ga_abs = xr.DataArray(data=Ga_abs, dims = G_angle.dims, coords=G_angle.isel(angle = G_angle.angle > 0).coords)
+    Ga_abs = xr.DataArray(data=Ga_abs.T, dims = G_angle.dims, coords=G_angle.isel(angle = G_angle.angle > 0).coords)
 
     Ga_abs_front = Ga_abs.isel(x= slice(0, 3))
     Ga_best = ((  Ga_abs_front * Ga_abs_front.N_data ).sum('x')/Ga_abs_front.N_data.sum('x'))
@@ -847,3 +848,5 @@ except:
 
 MT.json_save('B06_success', plot_path + '../', {'time':time.asctime( time.localtime(time.time()) )})
 print('done. saved target at ' + plot_path + '../B06_success' )
+
+# %%

--- a/data_prehandling/S03_download_WW3_hindcast_GLOBAL-30M.py
+++ b/data_prehandling/S03_download_WW3_hindcast_GLOBAL-30M.py
@@ -1,3 +1,4 @@
+# %%
 import os, sys
 #execfile(os.environ['PYTHONSTARTUP'])
 
@@ -27,6 +28,7 @@ var_list = [ 'dir', 'dp','fp', 'hs', 'ice', 'lm', 'spr', 't01', 't02', 't0m1', '
 'ptp0',  'ptp1',  'ptp2',  'ptp3',  'ptp4',  'ptp5',
 'phs0',  'phs1',  'phs2',  'phs3',  'phs4',  'phs5']
 
+# %%
 
 flist_parameters= list()
 subpath = 'GLOBMULTI_ERA5_GLOBCUR_01/'
@@ -89,3 +91,5 @@ for year in np.arange(2018, 2022):
 
 
 print( flist_parameters )
+
+# %%

--- a/modules/ICEsat2_SI_tools/beam_stats.py
+++ b/modules/ICEsat2_SI_tools/beam_stats.py
@@ -1,0 +1,249 @@
+import numpy as np
+import pandas as pd
+import spectral_estimates as spec
+#import io as io_local
+import ICEsat2_SI_tools.io as io_local
+
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+
+def derive_beam_statistics(Gd, all_beams,  Lmeter=10e3, dx =10):
+    """
+    this method returns a dict of dataframes with the beam statistics
+    Gd          is a dict of beam tables or a hdf5 file
+    all_beams   is a list of all beams
+    Lemter      is the length of the segment in meters for the statistics
+    dx          is the nominal resolution of the ATL06 data in meters
+    """
+    import h5py
+
+    D=dict()
+    for k in all_beams:
+        if isinstance(Gd, dict):
+            Gi = Gd[k]    
+        elif isinstance(Gd, h5py.File):
+            Gi  = io_local.get_beam_hdf_store(Gd[k])
+        else:
+            print('Gd is neither dict nor hdf5 file')
+            break
+
+        dd = Gi['h_mean']
+        xx = Gi['dist']
+
+        def get_var(sti):
+            mask = (sti[0] < xx) & (xx <= sti[1])
+            return np.nanvar(dd[mask])
+
+        def get_N(sti):
+            mask = (sti[0] < xx) & (xx <= sti[1])
+            return dd[mask].size
+
+        def get_lat(sti):
+            mask = (sti[0] < xx) & (xx <= sti[1])
+            return np.nanmean(Gi['lats'][mask])
+
+        iter_x       = spec.create_chunk_boundaries_unit_lengths( Lmeter, [ xx.min(), xx.max()],ov =0, iter_flag= False)[1,:]
+
+        stencil_iter = spec.create_chunk_boundaries_unit_lengths( Lmeter, [ xx.min(), xx.max()],ov =0, iter_flag= True)
+        var_list = np.array(list(map(get_var, stencil_iter)))
+
+        stencil_iter = spec.create_chunk_boundaries_unit_lengths( Lmeter, [ xx.min(), xx.max()],ov =0, iter_flag= True)
+        N_list   = np.array(list(map(get_N, stencil_iter)))
+
+        stencil_iter = spec.create_chunk_boundaries_unit_lengths( Lmeter, [ xx.min(), xx.max()],ov =0, iter_flag= True)
+        lat_list = np.array(list(map(get_lat, stencil_iter)))
+
+        # make Dataframe 
+        df = pd.DataFrame()
+        df['x'] = iter_x
+        df['lat'] = lat_list
+        df['var']    = var_list
+        df['N']      = N_list * 2* dx / Lmeter
+        
+        D[k] = df
+
+    return D
+
+def plot_beam_statistics(D, high_beams, low_beams, col_dict, track_name =None):
+    """
+    Plots the beam statistics in a 2 x 2 plot
+    D is a dict of dataframes with the beam statistics
+    high_beams is a list of high beams
+    low_beams is a list of low beams
+    col_dict is a dict with the colors for the beams
+    track_name is the name of the track
+    """
+    import matplotlib.pyplot as plt
+
+    if track_name is not None:
+        plt.suptitle(track_name, fontsize=10)
+
+    import matplotlib.gridspec as gridspec
+
+    gs = gridspec.GridSpec(2, 3)
+
+    # make 2 x 2 plot
+    ax1 = plt.subplot(gs[0, 0])
+    for k in high_beams:
+        plt.plot(D[k]['x']/1e3, np.sqrt(D[k]['var']), '.', color=  col_dict[k], markersize=4, label=k)
+
+    plt.title('high beams std', loc='left')
+    #plt.xlabel('along track distance (km)')
+    plt.ylabel('segment std log(m)')
+    #plt.ylim(0, 20)
+    ax1.set_yscale('log')
+
+    ax2 = plt.subplot(gs[1, 0])
+    for k in high_beams:
+        Di = D[k]['N']
+        Di[Di ==0] =np.nan
+        plt.plot(D[k]['x']/1e3, D[k]['N'], '.', color= col_dict[k], markersize=4, label=k)
+
+    plt.title('high beams N', loc='left')
+    plt.xlabel('along track distance (km)')
+    plt.ylabel('Point Density (m)')
+
+    ax3 = plt.subplot(gs[0, 1])
+    for k in low_beams:
+        plt.plot(D[k]['x']/1e3, np.sqrt(D[k]['var']), '.', color=  col_dict[k], markersize=4, label=k)
+
+    plt.title('low beams std', loc='left')
+    #plt.xlabel('along track distance (km)')
+    #plt.ylabel('segment std (m)')
+    #plt.ylim(0, 20)
+    ax3.set_yscale('log')
+
+    ax4 = plt.subplot(gs[1, 1])
+    for k in low_beams:
+        Di = D[k]['N']
+        Di[Di ==0] =np.nan
+        plt.plot(D[k]['x']/1e3, D[k]['N'], '.', color= col_dict[k], markersize=4, label=k)
+
+    plt.title('low beams N', loc='left')
+    plt.xlabel('along track distance (km)')
+    #plt.ylabel('Point density (m)')
+
+    ax5 = plt.subplot(gs[0:2, 2])
+
+    lat_shift = 0
+    for k in low_beams:
+        Di = D[k]
+        plt.scatter(Di['x']/1e3, Di['lat']+lat_shift, s= np.exp(Di['N'] *5) , marker='.', color=  col_dict[k],  label=k, alpha = 0.3)
+        lat_shift = lat_shift + 2
+
+    for k in high_beams:
+        Di = D[k]
+        plt.scatter(Di['x']/1e3, Di['lat']+lat_shift, s= np.exp(Di['N'] *5) , marker='.', color=  col_dict[k],  label=k, alpha = 0.3)
+        lat_shift = lat_shift + 2
+
+    plt.title('Density in space', loc='left')
+    plt.ylabel('Latitude (deg)')
+    plt.xlabel('along track distance (km)')
+    plt.legend()
+    plt.show()
+
+
+    # # make 2 x 2 plot
+    # plt.subplot(2, 3, 1)
+    # for k in high_beams:
+    #     plt.plot(D[k]['x']/1e3, np.sqrt(D[k]['var']), '.', color=  col_dict[k], markersize=4, label=k)
+
+    # plt.title('high beams std', loc='left')
+    # #plt.xlabel('along track distance (km)')
+    # plt.ylabel('segment std (m)')
+    # plt.ylim(0, 20)
+
+    # plt.subplot(2, 3, 3)
+    # for k in high_beams:
+    #     Di = D[k]['N']
+    #     Di[Di ==0] =np.nan
+    #     plt.plot(D[k]['lat'], D[k]['N'], '.', color= col_dict[k], markersize=4, label=k)
+
+    # plt.title('high beams N', loc='left')
+    # plt.xlabel('along track distance (km) or Lat')
+    # plt.ylabel('Point Density (m)')
+
+
+    # plt.subplot(2, 3, 2)
+    # for k in low_beams:
+    #     plt.plot(D[k]['x']/1e3, np.sqrt(D[k]['var']), '.', color=  col_dict[k], markersize=4, label=k)
+
+    # plt.title('low beams std', loc='left')
+    # #plt.xlabel('along track distance (km)')
+    # #plt.ylabel('segment std (m)')
+    # plt.ylim(0, 20)
+
+    # plt.subplot(2, 3, 4)
+    # for k in low_beams:
+    #     Di = D[k]['N']
+    #     Di[Di ==0] =np.nan
+    #     plt.plot(D[k]['lat'], D[k]['N'], '.', color= col_dict[k], markersize=4, label=k)
+
+    # plt.title('low beams N', loc='left')
+    # plt.xlabel('along track distance (km) or Lat')
+    # #plt.ylabel('Point density (m)')
+    # #return F
+
+    # plt.subplot(2,3, 5)
+    # plt.scatter(D['gt1l']['x']/1e3, D['gt1l']['lat'], s= np.exp(D['gt1l']['N'] *10) , marker='.', color=  col_dict['gt1l'],  label='gt1l', alpha = 0.3)
+
+    # plt.subplots_adjust(left=0.1, bottom=0.1, right=0.9, top=0.9, wspace=0.3, hspace=0.3)
+
+## plot track stats basics for sliderules ATL06 output
+
+def plot_ATL06_track_data( G2, cdict):
+    """
+    Plots the beam statistics in a 3 x 3 plot
+    G2      is a GeoDataFrame from SL (ATL06)
+    title   is the title of the plot
+    cdict   is a dict with the colors for each 'spot'
+    returns a figure object
+    """
+    gs = gridspec.GridSpec(3, 3)
+
+    ax1 = plt.subplot(gs[0, 0:2])
+    ax2 = plt.subplot(gs[1, 0:2])
+    ax3 = plt.subplot(gs[2, 0:2])
+    ax4 = plt.subplot(gs[0, 2])
+    ax5 = plt.subplot(gs[1, 2])
+    ax6 = plt.subplot(gs[2, 2])
+
+    for sp in G2['spot'].unique():
+        Gc = G2[G2['spot'] == 1]
+
+        Gc['h_mean_gradient'] = np.gradient(Gc['h_mean'])
+        ts_config = {'marker': '.', 'markersize': 0.2, 'linestyle': 'none', 'color': cdict[sp], 'alpha': 0.3}
+        hist_confit = {'density': True, 'color': cdict[sp], 'alpha': 0.3}
+
+        ax1.plot(Gc.geometry.y, Gc['h_mean'], **ts_config)
+        ax2.plot(Gc.geometry.y, Gc['h_mean_gradient'], **ts_config)
+        ax3.plot(Gc.geometry.y, Gc['n_fit_photons'], **ts_config)
+
+        Gc['h_mean'].plot.hist(ax=ax4, bins=30, **hist_confit)
+        Gc['h_mean_gradient'].plot.hist(ax=ax5, bins=np.linspace(-5, 5, 30), **hist_confit)
+        Gc['rms_misfit'].plot.hist(ax=ax6, bins=30, **hist_confit)
+
+    ax1.set_ylabel('h_mean (m)')
+    ax2.set_ylabel('slope (m/m)')
+    ax3.set_ylabel('N Photons')
+    ax3.set_xlabel('Latitude (degree)')
+    ax1.set_xticklabels([])
+    ax2.set_xticklabels([])
+
+    ax1.axhline(0, color='k', linestyle='-', linewidth=0.8)
+    ax2.axhline(0, color='k', linestyle='-', linewidth=0.8)
+
+    ax1.set_title('Height', loc='left')
+    ax2.set_title('Slope', loc='left')
+    ax3.set_title('Photons per extend', loc='left')
+
+    ax4.set_title('Histograms', loc='left')
+    ax5.set_title('Histograms', loc='left')
+
+    ax6.set_title('Error Hist.', loc='left')
+    ax6.set_xlabel('rms_misfit (m)')
+
+    for axi in [ax4, ax5, ax6]:
+        axi.set_ylabel('')
+
+    return [ax1, ax2, ax3, ax4, ax5, ax6]

--- a/modules/ICEsat2_SI_tools/sliderule_converter_tools.py
+++ b/modules/ICEsat2_SI_tools/sliderule_converter_tools.py
@@ -1,6 +1,20 @@
 
 from ipyleaflet import basemaps
 
+
+# height correction tools
+def correct_and_remove_height(Gi, height_limit):
+    """
+    corrects the height and removes the points with height +- height_limit
+    """
+    h_mean_corrected    = (Gi['h_mean'] - Gi['dem_h'])
+    false_height_mask   = abs(h_mean_corrected) > height_limit
+    Gi['h_mean']=h_mean_corrected    
+    Gi.drop(columns=['dem_h'], inplace=True)
+    return Gi[~false_height_mask]
+
+
+
 # polygon tools
 def make_plot_polygon(poly_test, color="green"):
     """ create a plot polygon from the given coordinates"""
@@ -60,10 +74,12 @@ def get_min_eq_dist(ppoly):
     """
     min_eq_dist= list()
     for point in ppoly:
-        point['distance'] = haversine(point['lon'], 0, point['lon'], point['lat'], arc=False)
-        #print(point['lat'], point['distance'])
-        min_eq_dist.append(point['distance'])
+        point['x_atc'] = haversine(point['lon'], 0, point['lon'], point['lat'], arc=False)
+        #print(point['lat'], point['x_atc'])
+        min_eq_dist.append(point['x_atc'])
     return min(min_eq_dist)*1e3 # in meters. needed for defining the x-axis
+
+
 
 
 def create_polygons(latR, lonR):
@@ -120,16 +136,16 @@ def ascending_test(track_data):
 
 def ascending_test_distance(track_data):
     """
-    test if the track is ascending or descending based on 'distance' column
+    test if the track is ascending or descending based on 'x_atc' column
     """
     # get the first and last point
     
 
-    first_point = abs(track_data.iloc[track_data['distance'].argmin()].geometry.y)
-    last_point  = abs(track_data.iloc[track_data['distance'].argmax()].geometry.y)
+    first_point = abs(track_data.iloc[track_data['x_atc'].argmin()].geometry.y)
+    last_point  = abs(track_data.iloc[track_data['x_atc'].argmax()].geometry.y)
 
-    # first_point = track_data.iloc[track_data.index.argmin()]['distance']
-    # last_point = track_data.iloc[track_data.index.argmax()]['distance']
+    # first_point = track_data.iloc[track_data.index.argmin()]['x_atc']
+    # last_point = track_data.iloc[track_data.index.argmax()]['x_atc']
     # get the time
     # first_time = cGPS.convert_GPS_time(first_point.index, first_point['rgt'], first_point['orbit_number'])
     # last_time = cGPS.convert_GPS_time(last_point['delta_time'], last_point['rgt'], last_point['orbit_number'])
@@ -205,7 +221,7 @@ def plot_reference_point_coordinates(tmp, start_point_dist, start_point):
     ax.set_title('RGT: ' + str(rgt), loc='left')
 
     ax = axx[1]
-    ax.plot(tmp['distance'], tmp.geometry.y ,'.', markersize=0.5, c=data_col, label ='data')
+    ax.plot(tmp['x_atc'], tmp.geometry.y ,'.', markersize=0.5, c=data_col, label ='data')
     ax.plot(start_point_dist, start_point.geometry.y ,'.', c =spoint_color, label='reference point')
 
     ax.set_xlabel('Distance from Equator')
@@ -316,10 +332,10 @@ def define_x_coordinate_in_polygon(table_data, polygon, round=True):
         min_eq_dist = np.round(get_min_eq_dist(polygon))
         
     if ascending_test(table_data):
-        table_data['x'] = table_data['distance'] - min_eq_dist
+        table_data['x'] = table_data['x_atc'] - min_eq_dist
     else:
         #print('descending')
-        table_data['x'] = ((np.pi * 6371*1e3) - min_eq_dist) - table_data['distance']
+        table_data['x'] = ((np.pi * 6371*1e3) - min_eq_dist) - table_data['x_atc']
 
     return table_data
 
@@ -343,9 +359,9 @@ def define_x_coordinate_with_RGT(table_data, Gtrack_lowest):
     start_point_dist, start_point = define_reference_distance_with_RGT(Gtrack_lowest, rgt, acending)
 
     if acending:
-        table_data['x'] = table_data['distance'] - start_point_dist
+        table_data['x'] = table_data['x_atc'] - start_point_dist
     else:
-        table_data['x'] = start_point_dist - table_data['distance']
+        table_data['x'] = start_point_dist - table_data['x_atc']
 
     return table_data
 
@@ -360,11 +376,11 @@ def define_x_coordinate_from_data(table_data):
     acending = ascending_test_distance(table_data)
     
     if acending:
-        start_point_dist = table_data['distance'].min()
-        table_data['x']  = table_data['distance'] - start_point_dist   
+        start_point_dist = table_data['x_atc'].min()
+        table_data['x']  = table_data['x_atc'] - start_point_dist   
     else:
-        start_point_dist = table_data['distance'].max()
-        table_data['x']  = start_point_dist - table_data['distance']
+        start_point_dist = table_data['x_atc'].max()
+        table_data['x']  = start_point_dist - table_data['x_atc']
     table_data.sort_values(by='x', inplace=True)
     table_data.reset_index(inplace=True)
     return table_data

--- a/modules/ICEsat2_SI_tools/sliderule_converter_tools.py
+++ b/modules/ICEsat2_SI_tools/sliderule_converter_tools.py
@@ -365,7 +365,8 @@ def define_x_coordinate_from_data(table_data):
     else:
         start_point_dist = table_data['distance'].max()
         table_data['x']  = start_point_dist - table_data['distance']
-
+    table_data.sort_values(by='x', inplace=True)
+    table_data.reset_index(inplace=True)
     return table_data
 
 


### PR DESCRIPTION
- This code is tested with the Python 3.11 environment. It needs to install 2 more modules, `siphon` and `piecewise-regression`
- The test case is now based on the `20190502052058_05180312_005_01` track, which should create the `SH_20190502_05180312` ID_name.
- Note that there is no need to download WW3 data a priory anymore since the data moved to a Thredds server. However, there is some missing variables in that catalog, such that we may need to change the URL of the data later again..
- `B04_angle.py` is only serial right now since the furniture.map() throws an error with the newer Python version.

the output should look like this:
https://drive.google.com/drive/folders/127O2hpyzyYQq-1JV32KtKOB8PIjXIarI?usp=share_link 

```
# download routine for single file using sliderule
python B01_SL_load_single_file.py 20190502052058_05180312_005_01 SH_testSLsinglefile2 True

# this code opens plotting windows that appearently now have to be closed manually
python B02_make_spectra_gFT.py SH_20190502_05180312 SH_testSLsinglefile2 True
python B03_plot_spectra_ov.py SH_20190502_05180312 SH_testSLsinglefile2 True

# A02 prior (S03_download_WW3_hindcast_GLOBAL-30M.py is not needed anymore) 
python A02c_IOWAGA_thredds_prior.py SH_20190502_05180312 SH_testSLsinglefile2 True

# parallel version does not work anymore so this is just serial code
python B04_angle.py SH_20190502_05180312 SH_testSLsinglefile2 True
python B05_define_angle.py SH_20190502_05180312 SH_testSLsinglefile2 True
python B06_correct_separate_var.py SH_20190502_05180312 SH_testSLsinglefile2 True

```

