### PR TITLE
fix: icesat2waves commands

### DIFF
--- a/.github/workflows/test-B01_SL_load_single_file.yml
+++ b/.github/workflows/test-B01_SL_load_single_file.yml
@@ -23,28 +23,17 @@ jobs:
         run: pip install .
       - name: List dependencies
         run: pip list
-      - name: test icesat2waves app
-        run: |
-            icesat2waves --help
-            icesat2waves load-file --help
-            icesat2waves make-spectra --help
-            icesat2waves plot-spectra --help
-            icesat2waves make-iowaga-threads-prior --help
-            icesat2waves make-b04-angle --help # prelim name
-            icesat2waves define-angle --help
-            icesat2waves correct-separate --help # prelim name
-
       - name: first step B01_SL_load_single_file
-        run: load-file --track-name 20190502052058_05180312_005_01 --batch-key SH_testSLsinglefile2 --output-dir ./work
+        run: icesat2waves load-file --track-name 20190502052058_05180312_005_01 --batch-key SH_testSLsinglefile2 --output-dir ./work
       - name: second step make_spectra
-        run: make-spectra --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
+        run: icesat2waves make-spectra --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
       - name: third step plot_spectra
-        run: plot-spectra --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
+        run: icesat2waves plot-spectra --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
       - name: fouth step IOWAGA threads 
-        run:  make-iowaga-threads-prior --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
+        run: icesat2waves make-iowaga-threads-prior --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
       - name: fifth step B04_angle
-        run: make-b04-angle --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
+        run: icesat2waves make-b04-angle --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
       - name: sixth step B04_define_angle
-        run: define-angle --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
+        run: icesat2waves define-angle --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
       - name: seventh step B06_correct_separate
-        run: correct-separate --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work
+        run: icesat2waves correct-separate --track-name SH_20190502_05180312 --batch-key SH_testSLsinglefile2 --output-dir ./work

--- a/src/icesat2_tracks/analysis_db/A02c_IOWAGA_thredds_prior.py
+++ b/src/icesat2_tracks/analysis_db/A02c_IOWAGA_thredds_prior.py
@@ -32,17 +32,8 @@ from icesat2_tracks.clitools import (
     makeapp,
 )
 
-color_schemes.colormaps2(21)
-matplotlib.use("Agg")  # prevent plot windows from opening
 
-dtime = 4  # in hours
-
-# IOWAGA constants
-data_url = "https://tds3.ifremer.fr/thredds/IOWAGA-WW3-FORECAST/IOWAGA-WW3-FORECAST_GLOBMULTI_GLOB-30M.xml"
-dataset_key = "IOWAGA-WW3-FORECAST_GLOBMULTI_GLOB-30M_FIELD_NC_MARC_WW3-GLOB-30M"
-
-
-def get_iowaga(data_url=data_url, dataset_key=dataset_key):
+def get_iowaga(data_url, dataset_key):
     ## load WW3 data
     # ECMWF hindcast
     # data_url = 'https://tds3.ifremer.fr/thredds/IOWAGA-WW3-HINDCAST/IOWAGA-GLOBAL_ECMWF-WW3-HINDCAST_FULL_TIME_SERIE.xml'
@@ -191,14 +182,20 @@ def run_A02c_IOWAGA_thredds_prior(
     track_name: str = typer.Option(..., callback=validate_track_name_steps_gt_1),
     batch_key: str = typer.Option(..., callback=validate_batch_key),
     ID_flag: bool = True,
-    data_url: str = typer.Option(data_url),
-    dataset_key: str = typer.Option(dataset_key),
     output_dir: str = typer.Option(..., callback=validate_output_dir),
     verbose: bool = False,
 ):
     """
     TODO: add docstring
     """
+    color_schemes.colormaps2(21)
+    matplotlib.use("Agg")  # prevent plot windows from opening
+
+    dtime = 4  # in hours
+
+    # IOWAGA constants
+    data_url = "https://tds3.ifremer.fr/thredds/IOWAGA-WW3-FORECAST/IOWAGA-WW3-FORECAST_GLOBMULTI_GLOB-30M.xml"
+    dataset_key = "IOWAGA-WW3-FORECAST_GLOBMULTI_GLOB-30M_FIELD_NC_MARC_WW3-GLOB-30M"
 
     track_name, batch_key, _ = io.init_from_input(
         [
@@ -646,7 +643,9 @@ def run_A02c_IOWAGA_thredds_prior(
         echo("done")
 
 
-make_iowaga_threads_prior_app = makeapp(run_A02c_IOWAGA_thredds_prior, name="threads-prior")
+make_iowaga_threads_prior_app = makeapp(
+    run_A02c_IOWAGA_thredds_prior, name="threads-prior"
+)
 
 if __name__ == "__main__":
     make_iowaga_threads_prior_app()

--- a/src/icesat2_tracks/app.py
+++ b/src/icesat2_tracks/app.py
@@ -24,7 +24,9 @@ from icesat2_tracks.analysis_db.B04_angle import run_B04_angle as _run_B04_angle
 
 from icesat2_tracks.analysis_db.B05_define_angle import define_angle as _define_angle
 
-from icesat2_tracks.analysis_db.B06_correct_separate_var import run_B06_correct_separate_var as _run_correct_separate_var
+from icesat2_tracks.analysis_db.B06_correct_separate_var import (
+    run_B06_correct_separate_var as _run_correct_separate_var,
+)
 
 
 from icesat2_tracks.clitools import (
@@ -48,7 +50,13 @@ def run_job(
     output_dir: str = validate_output_dir_opt,
     verbose: bool = False,
 ):
-    analysis_func(track_name, batch_key, ID_flag, output_dir, verbose)
+    analysis_func(
+        track_name=track_name,
+        batch_key=batch_key,
+        ID_flag=ID_flag,
+        output_dir=output_dir,
+        verbose=verbose,
+    )
 
 
 @app.command(help=_loadfile.__doc__)
@@ -84,15 +92,6 @@ def plot_spectra(
     run_job(_plotspectra, track_name, batch_key, ID_flag, output_dir, verbose)
 
 
-@app.command(help=_plotspectra.__doc__)
-def separate_var(
-    track_name: str = validate_track_name_gt_1_opt,
-    batch_key: str = validate_batch_key_opt,
-    ID_flag: bool = True,
-    output_dir: str = validate_output_dir_opt,
-):
-    run_job(_plotspectra, track_name, batch_key, ID_flag, output_dir)
-
 @app.command(help=_threddsprior.__doc__)
 def make_iowaga_threads_prior(  # TODO: revise naming @mochell
     track_name: str = validate_track_name_gt_1_opt,
@@ -114,6 +113,7 @@ def make_b04_angle(  # TODO: revise naming @mochell
 ):
     run_job(_run_B04_angle, track_name, batch_key, ID_flag, output_dir, verbose)
 
+
 @app.command(help=_define_angle.__doc__)
 def define_angle(
     track_name: str = validate_track_name_gt_1_opt,
@@ -123,7 +123,7 @@ def define_angle(
     verbose: bool = False,
 ):
     run_job(_define_angle, track_name, batch_key, ID_flag, output_dir, verbose)
-    
+
 
 @app.command(help=_run_correct_separate_var.__doc__)
 def correct_separate(  # TODO: rename with a verb or something
@@ -134,6 +134,7 @@ def correct_separate(  # TODO: rename with a verb or something
     verbose: bool = False,
 ):
     run_job(_run_correct_separate_var, track_name, batch_key, ID_flag, output_dir)
+
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
There was a bug invoking the commands `load-file` (thanks @hollandjg for catching that one!) and `make-iowaga-threads-prior` from `icesat2waves`. This patch fixes those problems.

It also updates the workflow file to call the commands from the global app.