### PR TITLE
Refactor test suite test_steps.py to run step that takes the longest first

### DIFF
--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -322,6 +322,10 @@ def teardown_module():
     """
     shutil.rmtree(__outdir[-1])
 
+def test_step5():
+    # Step 5: B04_angle.py ~ 9 min
+    assert run_test(script5, paths5)
+
 
 def test_step1():
     # Step 1: B01_SL_load_single_file.py ~ 2 minutes
@@ -377,11 +381,6 @@ def test_step4():
     # check stochastic paths
     t2 = check_file_exists(dir4, prefix4)
     assert t2
-
-
-def test_step5():
-    # Step 5: B04_angle.py ~ 9 min
-    assert run_test(script5, paths5)
 
 
 def test_step6():


### PR DESCRIPTION
The pytest's `xdist` plug-in seems to assign test functions to workers in the order that they are listed in the file. Because default GitHub runners only have 4 cores, listed fifth `test_step5` -- the step that takes the longest to complete -- does not get picked up immediately. This PR lists this step before the others; this should make things run much faster in general.